### PR TITLE
Add Pi-hole v6 REST client and DNS collector group

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23
 
 require (
 	github.com/prometheus/client_golang v1.20.5
+	github.com/prometheus/common v0.55.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -14,7 +15,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
-	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	golang.org/x/sys v0.22.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect

--- a/internal/exporter/dns.go
+++ b/internal/exporter/dns.go
@@ -1,0 +1,262 @@
+package exporter
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/reloaded/prometheus_pihole_exporter/internal/pihole"
+)
+
+// dnsCollector pulls DNS / blocking / FTL metrics out of Pi-hole's
+// REST API. One Collector instance per Pi-hole instance — the
+// `instance` label is baked into every metric via ConstLabels.
+type dnsCollector struct {
+	instance string
+	client   *pihole.Client
+	logger   *slog.Logger
+
+	// Top-line DNS counters / gauges
+	queriesTotal      *prometheus.Desc
+	queriesBlocked    *prometheus.Desc
+	queriesForwarded  *prometheus.Desc
+	queriesCached     *prometheus.Desc
+	queriesByType     *prometheus.Desc
+	queriesByStatus   *prometheus.Desc
+	queriesByReply    *prometheus.Desc
+	queriesUnique     *prometheus.Desc
+	queriesFrequency  *prometheus.Desc
+	queriesPctBlocked *prometheus.Desc
+
+	// Clients
+	clientsActive *prometheus.Desc
+	clientsTotal  *prometheus.Desc
+
+	// Gravity (blocklist)
+	gravityDomains      *prometheus.Desc
+	gravityLastUpdateTs *prometheus.Desc
+
+	// Per-upstream (ip, name, port)
+	upstreamQueries      *prometheus.Desc
+	upstreamResponseSecs *prometheus.Desc
+	upstreamVarianceSecs *prometheus.Desc
+
+	// Blocking state
+	blockingEnabled *prometheus.Desc
+
+	// FTL daemon health (selected fields)
+	ftlPrivacyLevel   *prometheus.Desc
+	ftlMemPercent     *prometheus.Desc
+	ftlCPUPercent     *prometheus.Desc
+	ftlClientsActive  *prometheus.Desc
+	ftlClientsTotal   *prometheus.Desc
+	dnsmasqCacheIns   *prometheus.Desc
+	dnsmasqCacheFreed *prometheus.Desc
+	dnsmasqForwarded  *prometheus.Desc
+	dnsmasqAuth       *prometheus.Desc
+	dnsmasqLocal      *prometheus.Desc
+	dnsmasqStale      *prometheus.Desc
+	dnsmasqUnanswered *prometheus.Desc
+
+	// Info gauge (constant 1, labels carry version strings)
+	info *prometheus.Desc
+
+	// Per-collector health: did the call succeed this scrape?
+	collectorUp *prometheus.Desc
+}
+
+func newDNSCollector(instance string, client *pihole.Client, logger *slog.Logger) prometheus.Collector {
+	labels := prometheus.Labels{"instance": instance}
+	d := func(name, help string, varLabels ...string) *prometheus.Desc {
+		return prometheus.NewDesc(name, help, varLabels, labels)
+	}
+	return &dnsCollector{
+		instance: instance,
+		client:   client,
+		logger:   logger,
+
+		queriesTotal:      d("pihole_dns_queries_total", "Pi-hole DNS queries handled today (resets at midnight, treat as a Counter)."),
+		queriesBlocked:    d("pihole_dns_queries_blocked_total", "Pi-hole DNS queries blocked today (resets at midnight)."),
+		queriesForwarded:  d("pihole_dns_queries_forwarded_total", "Pi-hole DNS queries forwarded to upstream resolvers today (resets at midnight)."),
+		queriesCached:     d("pihole_dns_queries_cached_total", "Pi-hole DNS queries answered from local cache today (resets at midnight)."),
+		queriesByType:     d("pihole_dns_queries_by_type_total", "Pi-hole DNS queries today, partitioned by record type (resets at midnight).", "type"),
+		queriesByStatus:   d("pihole_dns_queries_by_status_total", "Pi-hole DNS queries today, partitioned by FTL status (resets at midnight).", "status"),
+		queriesByReply:    d("pihole_dns_queries_by_reply_total", "Pi-hole DNS queries today, partitioned by reply category (resets at midnight).", "reply"),
+		queriesUnique:     d("pihole_dns_queries_unique_domains", "Distinct domains queried today (gauge)."),
+		queriesFrequency:  d("pihole_dns_queries_per_second", "Pi-hole's reported short-window query rate (gauge)."),
+		queriesPctBlocked: d("pihole_dns_queries_blocked_ratio", "Fraction of today's queries that were blocked (0–1)."),
+
+		clientsActive: d("pihole_dns_clients_active", "Distinct clients seen in the rolling active window."),
+		clientsTotal:  d("pihole_dns_clients_total", "Distinct clients ever seen by this Pi-hole."),
+
+		gravityDomains:      d("pihole_gravity_domains", "Number of domains in the gravity (blocklist) table."),
+		gravityLastUpdateTs: d("pihole_gravity_last_update_timestamp_seconds", "Unix timestamp of the last gravity database refresh."),
+
+		upstreamQueries:      d("pihole_dns_upstream_queries_total", "Today's queries forwarded to a given upstream destination (resets at midnight).", "upstream", "ip", "port"),
+		upstreamResponseSecs: d("pihole_dns_upstream_response_seconds", "Mean response time from a given upstream destination (Pi-hole's reported value).", "upstream", "ip", "port"),
+		upstreamVarianceSecs: d("pihole_dns_upstream_response_variance_seconds", "Variance of response time from a given upstream destination (Pi-hole's reported value).", "upstream", "ip", "port"),
+
+		blockingEnabled: d("pihole_blocking_enabled", "1 if Pi-hole's blocking is currently enabled, 0 otherwise (disabled / failed / unknown)."),
+
+		ftlPrivacyLevel:   d("pihole_ftl_privacy_level", "FTL privacy level (0=show everything … 3=anonymous)."),
+		ftlMemPercent:     d("pihole_ftl_memory_percent", "FTL daemon memory usage (percent of system memory)."),
+		ftlCPUPercent:     d("pihole_ftl_cpu_percent", "FTL daemon CPU usage (percent)."),
+		ftlClientsActive:  d("pihole_ftl_clients_active", "Active client count reported by FTL."),
+		ftlClientsTotal:   d("pihole_ftl_clients_total", "Total client count reported by FTL."),
+		dnsmasqCacheIns:   d("pihole_dnsmasq_cache_inserted_total", "dnsmasq cache insertions since FTL start."),
+		dnsmasqCacheFreed: d("pihole_dnsmasq_cache_live_freed_total", "dnsmasq cache entries evicted live since FTL start."),
+		dnsmasqForwarded:  d("pihole_dnsmasq_queries_forwarded_total", "dnsmasq queries forwarded since FTL start."),
+		dnsmasqAuth:       d("pihole_dnsmasq_queries_auth_answered_total", "dnsmasq queries answered authoritatively since FTL start."),
+		dnsmasqLocal:      d("pihole_dnsmasq_queries_local_answered_total", "dnsmasq queries answered locally since FTL start."),
+		dnsmasqStale:      d("pihole_dnsmasq_queries_stale_answered_total", "dnsmasq queries answered from stale cache since FTL start."),
+		dnsmasqUnanswered: d("pihole_dnsmasq_queries_unanswered_total", "dnsmasq queries left unanswered since FTL start."),
+
+		info: d("pihole_info", "Pi-hole component versions reported by the API. Always 1; labels carry the strings.", "core_version", "ftl_version", "web_version"),
+
+		collectorUp: d("pihole_collector_up", "1 if a given collector group's scrape succeeded, 0 otherwise.", "collector"),
+	}
+}
+
+func (c *dnsCollector) Describe(ch chan<- *prometheus.Desc) {
+	descs := []*prometheus.Desc{
+		c.queriesTotal, c.queriesBlocked, c.queriesForwarded, c.queriesCached,
+		c.queriesByType, c.queriesByStatus, c.queriesByReply,
+		c.queriesUnique, c.queriesFrequency, c.queriesPctBlocked,
+		c.clientsActive, c.clientsTotal,
+		c.gravityDomains, c.gravityLastUpdateTs,
+		c.upstreamQueries, c.upstreamResponseSecs, c.upstreamVarianceSecs,
+		c.blockingEnabled,
+		c.ftlPrivacyLevel, c.ftlMemPercent, c.ftlCPUPercent,
+		c.ftlClientsActive, c.ftlClientsTotal,
+		c.dnsmasqCacheIns, c.dnsmasqCacheFreed, c.dnsmasqForwarded,
+		c.dnsmasqAuth, c.dnsmasqLocal, c.dnsmasqStale, c.dnsmasqUnanswered,
+		c.info, c.collectorUp,
+	}
+	for _, d := range descs {
+		ch <- d
+	}
+}
+
+// Collect runs the configured Pi-hole REST calls and emits one batch of
+// metrics. The collector splits work across four endpoints, each guarded
+// independently — a single failed endpoint still lets the others publish
+// what they got. `pihole_collector_up{collector="dns"}` ends as 1 only
+// when every endpoint succeeded.
+func (c *dnsCollector) Collect(ch chan<- prometheus.Metric) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	allOK := true
+
+	var summary pihole.StatsSummary
+	if err := c.client.Get(ctx, "/api/stats/summary", &summary); err != nil {
+		c.logger.Warn("dns: summary failed", "instance", c.instance, "err", err)
+		allOK = false
+	} else {
+		c.emitSummary(ch, summary)
+	}
+
+	var upstreams pihole.StatsUpstreams
+	if err := c.client.Get(ctx, "/api/stats/upstreams", &upstreams); err != nil {
+		c.logger.Warn("dns: upstreams failed", "instance", c.instance, "err", err)
+		allOK = false
+	} else {
+		c.emitUpstreams(ch, upstreams)
+	}
+
+	var blocking pihole.DNSBlocking
+	if err := c.client.Get(ctx, "/api/dns/blocking", &blocking); err != nil {
+		c.logger.Warn("dns: blocking failed", "instance", c.instance, "err", err)
+		allOK = false
+	} else {
+		ch <- prometheus.MustNewConstMetric(c.blockingEnabled, prometheus.GaugeValue, blocking.Enabled())
+	}
+
+	var ftl pihole.InfoFTL
+	if err := c.client.Get(ctx, "/api/info/ftl", &ftl); err != nil {
+		c.logger.Warn("dns: ftl info failed", "instance", c.instance, "err", err)
+		allOK = false
+	} else {
+		c.emitFTL(ch, ftl)
+	}
+
+	var ver pihole.InfoVersion
+	if err := c.client.Get(ctx, "/api/info/version", &ver); err != nil {
+		c.logger.Warn("dns: version info failed", "instance", c.instance, "err", err)
+		allOK = false
+	} else {
+		ch <- prometheus.MustNewConstMetric(c.info, prometheus.GaugeValue, 1,
+			ver.CoreVersion(), ver.FTLVersion(), ver.WebVersion())
+	}
+
+	upVal := 0.0
+	if allOK {
+		upVal = 1
+	}
+	ch <- prometheus.MustNewConstMetric(c.collectorUp, prometheus.GaugeValue, upVal, "dns")
+}
+
+func (c *dnsCollector) emitSummary(ch chan<- prometheus.Metric, s pihole.StatsSummary) {
+	q := s.Queries
+	ch <- prometheus.MustNewConstMetric(c.queriesTotal, prometheus.CounterValue, float64(q.Total))
+	ch <- prometheus.MustNewConstMetric(c.queriesBlocked, prometheus.CounterValue, float64(q.Blocked))
+	ch <- prometheus.MustNewConstMetric(c.queriesForwarded, prometheus.CounterValue, float64(q.Forwarded))
+	ch <- prometheus.MustNewConstMetric(c.queriesCached, prometheus.CounterValue, float64(q.Cached))
+	ch <- prometheus.MustNewConstMetric(c.queriesUnique, prometheus.GaugeValue, float64(q.UniqueDomains))
+	ch <- prometheus.MustNewConstMetric(c.queriesFrequency, prometheus.GaugeValue, q.Frequency)
+	ch <- prometheus.MustNewConstMetric(c.queriesPctBlocked, prometheus.GaugeValue, q.PercentBlocked/100)
+
+	for k, v := range q.Types {
+		ch <- prometheus.MustNewConstMetric(c.queriesByType, prometheus.CounterValue, float64(v), strings.ToUpper(k))
+	}
+	for k, v := range q.Status {
+		ch <- prometheus.MustNewConstMetric(c.queriesByStatus, prometheus.CounterValue, float64(v), k)
+	}
+	for k, v := range q.Replies {
+		ch <- prometheus.MustNewConstMetric(c.queriesByReply, prometheus.CounterValue, float64(v), k)
+	}
+
+	ch <- prometheus.MustNewConstMetric(c.clientsActive, prometheus.GaugeValue, float64(s.Clients.Active))
+	ch <- prometheus.MustNewConstMetric(c.clientsTotal, prometheus.GaugeValue, float64(s.Clients.Total))
+
+	ch <- prometheus.MustNewConstMetric(c.gravityDomains, prometheus.GaugeValue, float64(s.Gravity.DomainsBeingBlocked))
+	ch <- prometheus.MustNewConstMetric(c.gravityLastUpdateTs, prometheus.GaugeValue, float64(s.Gravity.LastUpdate))
+}
+
+func (c *dnsCollector) emitUpstreams(ch chan<- prometheus.Metric, u pihole.StatsUpstreams) {
+	for _, up := range u.Upstreams {
+		port := upstreamPortLabel(up.Port)
+		ch <- prometheus.MustNewConstMetric(c.upstreamQueries, prometheus.CounterValue, float64(up.Count), up.Name, up.IP, port)
+		ch <- prometheus.MustNewConstMetric(c.upstreamResponseSecs, prometheus.GaugeValue, up.Statistics.Response, up.Name, up.IP, port)
+		ch <- prometheus.MustNewConstMetric(c.upstreamVarianceSecs, prometheus.GaugeValue, up.Statistics.Variance, up.Name, up.IP, port)
+	}
+}
+
+func (c *dnsCollector) emitFTL(ch chan<- prometheus.Metric, ftl pihole.InfoFTL) {
+	f := ftl.FTL
+	ch <- prometheus.MustNewConstMetric(c.ftlPrivacyLevel, prometheus.GaugeValue, float64(f.PrivacyLevel))
+	ch <- prometheus.MustNewConstMetric(c.ftlMemPercent, prometheus.GaugeValue, f.MemPercent)
+	ch <- prometheus.MustNewConstMetric(c.ftlCPUPercent, prometheus.GaugeValue, f.CPUPercent)
+	ch <- prometheus.MustNewConstMetric(c.ftlClientsActive, prometheus.GaugeValue, float64(f.Clients.Active))
+	ch <- prometheus.MustNewConstMetric(c.ftlClientsTotal, prometheus.GaugeValue, float64(f.Clients.Total))
+
+	d := f.DNSMasq
+	ch <- prometheus.MustNewConstMetric(c.dnsmasqCacheIns, prometheus.CounterValue, float64(d.DNSCacheInserted))
+	ch <- prometheus.MustNewConstMetric(c.dnsmasqCacheFreed, prometheus.CounterValue, float64(d.DNSCacheLiveFreed))
+	ch <- prometheus.MustNewConstMetric(c.dnsmasqForwarded, prometheus.CounterValue, float64(d.DNSQueriesForwarded))
+	ch <- prometheus.MustNewConstMetric(c.dnsmasqAuth, prometheus.CounterValue, float64(d.DNSAuthAnswered))
+	ch <- prometheus.MustNewConstMetric(c.dnsmasqLocal, prometheus.CounterValue, float64(d.DNSLocalAnswered))
+	ch <- prometheus.MustNewConstMetric(c.dnsmasqStale, prometheus.CounterValue, float64(d.DNSStaleAnswered))
+	ch <- prometheus.MustNewConstMetric(c.dnsmasqUnanswered, prometheus.CounterValue, float64(d.DNSUnansweredQueries))
+}
+
+func upstreamPortLabel(p int) string {
+	if p == 0 {
+		return ""
+	}
+	return strconv.Itoa(p)
+}

--- a/internal/exporter/dns_test.go
+++ b/internal/exporter/dns_test.go
@@ -1,0 +1,214 @@
+package exporter
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/expfmt"
+
+	"github.com/reloaded/prometheus_pihole_exporter/internal/pihole"
+)
+
+// fakePihole is a minimal in-memory Pi-hole that can be steered per-test
+// via responses keyed on path. It handles the v6 auth handshake out of
+// the box.
+type fakePihole struct {
+	t         *testing.T
+	responses map[string]string // path → JSON body
+	status    map[string]int    // optional override (defaults to 200)
+}
+
+func (f *fakePihole) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/auth" {
+			_, _ = io.Copy(io.Discard, r.Body)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"session":{"valid":true,"sid":"S","validity":1800}}`))
+			return
+		}
+		body, ok := f.responses[r.URL.Path]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		if code := f.status[r.URL.Path]; code != 0 {
+			w.WriteHeader(code)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	})
+}
+
+// gatherText returns the rendered text-format metrics for the given
+// collector — easier to assert against than the raw protobuf model.
+func gatherText(t *testing.T, c prometheus.Collector) string {
+	t.Helper()
+	r := prometheus.NewRegistry()
+	r.MustRegister(c)
+	mfs, err := r.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	var buf bytes.Buffer
+	enc := expfmt.NewEncoder(&buf, expfmt.NewFormat(expfmt.TypeTextPlain))
+	for _, mf := range mfs {
+		if err := enc.Encode(mf); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	}
+	return buf.String()
+}
+
+func TestDNSCollector_Summary(t *testing.T) {
+	t.Parallel()
+
+	summary := pihole.StatsSummary{}
+	summary.Queries.Total = 1000
+	summary.Queries.Blocked = 100
+	summary.Queries.Forwarded = 600
+	summary.Queries.Cached = 300
+	summary.Queries.PercentBlocked = 10.0
+	summary.Queries.UniqueDomains = 250
+	summary.Queries.Frequency = 3.5
+	summary.Queries.Types = map[string]int64{"A": 700, "AAAA": 200, "MX": 100}
+	summary.Queries.Status = map[string]int64{"GRAVITY": 100, "FORWARDED": 600, "CACHE": 300}
+	summary.Queries.Replies = map[string]int64{"NXDOMAIN": 5, "NODATA": 10, "IP": 985}
+	summary.Clients.Active = 12
+	summary.Clients.Total = 50
+	summary.Gravity.DomainsBeingBlocked = 250000
+	summary.Gravity.LastUpdate = 1700000000
+	summaryJSON, _ := json.Marshal(summary)
+
+	upstreams := pihole.StatsUpstreams{
+		ForwardedQueries: 600,
+		TotalQueries:     1000,
+	}
+	upstreams.Upstreams = append(upstreams.Upstreams, struct {
+		IP         string `json:"ip"`
+		Name       string `json:"name"`
+		Port       int    `json:"port"`
+		Count      int64  `json:"count"`
+		Statistics struct {
+			Response float64 `json:"response"`
+			Variance float64 `json:"variance"`
+		} `json:"statistics"`
+	}{IP: "9.9.9.9", Name: "9.9.9.9#53", Port: 53, Count: 600, Statistics: struct {
+		Response float64 `json:"response"`
+		Variance float64 `json:"variance"`
+	}{Response: 0.05, Variance: 0.001}})
+	upstreamsJSON, _ := json.Marshal(upstreams)
+
+	srv := httptest.NewServer((&fakePihole{
+		t: t,
+		responses: map[string]string{
+			"/api/stats/summary":   string(summaryJSON),
+			"/api/stats/upstreams": string(upstreamsJSON),
+			"/api/dns/blocking":    `{"blocking":"enabled","timer":null}`,
+			"/api/info/ftl":        `{"ftl":{"privacy_level":0,"%mem":1.5,"%cpu":0.7,"clients":{"total":50,"active":12},"dnsmasq":{"dns_cache_inserted":4242,"dns_cache_live_freed":11,"dns_queries_forwarded":600,"dns_auth_answered":12,"dns_local_answered":300,"dns_stale_answered":5,"dns_unanswered_queries":2}}}`,
+			"/api/info/version":    `{"version":{"core":{"local":{"version":"v6.0.0"}},"ftl":{"local":{"version":"v6.0.1"}},"web":{"local":{"version":"v6.0.0"}}}}`,
+		},
+	}).handler())
+	defer srv.Close()
+
+	c := newDNSCollector("primary",
+		pihole.NewClient(pihole.Options{BaseURL: srv.URL, Password: "x"}),
+		slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	got := gatherText(t, c)
+
+	for _, want := range []string{
+		`pihole_dns_queries_total{instance="primary"} 1000`,
+		`pihole_dns_queries_blocked_total{instance="primary"} 100`,
+		`pihole_dns_queries_forwarded_total{instance="primary"} 600`,
+		`pihole_dns_queries_cached_total{instance="primary"} 300`,
+		`pihole_dns_queries_blocked_ratio{instance="primary"} 0.1`,
+		`pihole_dns_queries_unique_domains{instance="primary"} 250`,
+		`pihole_dns_queries_per_second{instance="primary"} 3.5`,
+		`pihole_dns_clients_active{instance="primary"} 12`,
+		`pihole_dns_clients_total{instance="primary"} 50`,
+		`pihole_gravity_domains{instance="primary"} 250000`,
+		`pihole_gravity_last_update_timestamp_seconds{instance="primary"} 1.7e+09`,
+		`pihole_blocking_enabled{instance="primary"} 1`,
+		`pihole_dns_queries_by_type_total{instance="primary",type="A"} 700`,
+		`pihole_dns_queries_by_type_total{instance="primary",type="AAAA"} 200`,
+		`pihole_dns_queries_by_status_total{instance="primary",status="GRAVITY"} 100`,
+		`pihole_dns_queries_by_reply_total{instance="primary",reply="NXDOMAIN"} 5`,
+		`pihole_dns_upstream_queries_total{instance="primary",ip="9.9.9.9",port="53",upstream="9.9.9.9#53"} 600`,
+		`pihole_dns_upstream_response_seconds{instance="primary",ip="9.9.9.9",port="53",upstream="9.9.9.9#53"} 0.05`,
+		`pihole_ftl_memory_percent{instance="primary"} 1.5`,
+		`pihole_ftl_cpu_percent{instance="primary"} 0.7`,
+		`pihole_dnsmasq_cache_inserted_total{instance="primary"} 4242`,
+		`pihole_dnsmasq_queries_forwarded_total{instance="primary"} 600`,
+		`pihole_info{core_version="v6.0.0",ftl_version="v6.0.1",instance="primary",web_version="v6.0.0"} 1`,
+		`pihole_collector_up{collector="dns",instance="primary"} 1`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing or different:\n  want substring: %q\n  in metrics:\n%s", want, got)
+		}
+	}
+}
+
+func TestDNSCollector_BlockingDisabled(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer((&fakePihole{
+		t: t,
+		responses: map[string]string{
+			"/api/stats/summary":   `{"queries":{}}`,
+			"/api/stats/upstreams": `{"upstreams":[]}`,
+			"/api/dns/blocking":    `{"blocking":"disabled","timer":300}`,
+			"/api/info/ftl":        `{"ftl":{}}`,
+			"/api/info/version":    `{"version":{}}`,
+		},
+	}).handler())
+	defer srv.Close()
+
+	c := newDNSCollector("primary",
+		pihole.NewClient(pihole.Options{BaseURL: srv.URL, Password: "x"}),
+		slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	got := gatherText(t, c)
+	if !strings.Contains(got, `pihole_blocking_enabled{instance="primary"} 0`) {
+		t.Fatalf("expected blocking_enabled=0 (disabled), got:\n%s", got)
+	}
+	if !strings.Contains(got, `pihole_info{core_version="unknown",ftl_version="unknown",instance="primary",web_version="unknown"} 1`) {
+		t.Fatalf("expected info gauge with unknown versions, got:\n%s", got)
+	}
+}
+
+func TestDNSCollector_PartialFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer((&fakePihole{
+		t: t,
+		responses: map[string]string{
+			"/api/stats/summary":   `{"queries":{"total":1}}`,
+			"/api/stats/upstreams": `not even valid json`,
+			"/api/dns/blocking":    `{"blocking":"enabled"}`,
+			"/api/info/ftl":        `{"ftl":{}}`,
+			"/api/info/version":    `{"version":{}}`,
+		},
+	}).handler())
+	defer srv.Close()
+
+	c := newDNSCollector("primary",
+		pihole.NewClient(pihole.Options{BaseURL: srv.URL, Password: "x"}),
+		slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	got := gatherText(t, c)
+	// Summary succeeded, upstreams failed → collector_up should be 0,
+	// but the summary metrics should still have been emitted.
+	if !strings.Contains(got, `pihole_collector_up{collector="dns",instance="primary"} 0`) {
+		t.Fatalf("expected collector_up=0 when an endpoint fails, got:\n%s", got)
+	}
+	if !strings.Contains(got, `pihole_dns_queries_total{instance="primary"} 1`) {
+		t.Fatalf("expected partial summary metrics, got:\n%s", got)
+	}
+}

--- a/internal/exporter/probe.go
+++ b/internal/exporter/probe.go
@@ -6,32 +6,55 @@
 // gathered into a fresh registry, and the resulting metrics are written
 // out. This keeps instances isolated from each other and avoids global
 // metric churn when one instance is briefly unreachable.
-//
-// Collector implementations themselves are stubbed out at scaffold time
-// and will land in follow-up PRs (one per collector group).
 package exporter
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
+	"os"
+	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/reloaded/prometheus_pihole_exporter/internal/config"
+	"github.com/reloaded/prometheus_pihole_exporter/internal/pihole"
 )
 
+// pingTimeout caps the auth check the probe handler runs before
+// registering collectors. Independent of per-collector timeouts so a
+// single slow Pi-hole can't block /probe past this deadline.
+const pingTimeout = 10 * time.Second
+
 // NewProbeHandler builds the HTTP handler served at /probe.
+//
+// Each Pi-hole instance gets a single shared *pihole.Client (reused
+// across scrapes so the v6 session SID gets cached) and a freshly-built
+// registry per request.
 func NewProbeHandler(cfg *config.Config, logger *slog.Logger) http.Handler {
-	return &probeHandler{
-		cfg:    cfg,
-		logger: logger,
+	h := &probeHandler{
+		cfg:     cfg,
+		logger:  logger,
+		clients: make(map[string]*pihole.Client, len(cfg.Instances)),
 	}
+	for id, inst := range cfg.Instances {
+		h.clients[id] = pihole.NewClient(pihole.Options{
+			BaseURL:            inst.URL,
+			Password:           os.Getenv(inst.AppPasswordEnv),
+			Timeout:            inst.Timeout,
+			InsecureSkipVerify: inst.InsecureSkipVerify,
+		})
+	}
+	return h
 }
 
 type probeHandler struct {
-	cfg    *config.Config
-	logger *slog.Logger
+	cfg     *config.Config
+	logger  *slog.Logger
+	mu      sync.Mutex // guards clients
+	clients map[string]*pihole.Client
 }
 
 func (h *probeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -46,27 +69,67 @@ func (h *probeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "unknown target", http.StatusNotFound)
 		return
 	}
+	h.mu.Lock()
+	client := h.clients[target]
+	h.mu.Unlock()
 
 	registry := prometheus.NewRegistry()
+	logger := h.logger.With("instance", target)
 
-	// Per-probe metric describing whether collection succeeded end-to-end.
-	// This stays in place even after real collectors land; alerts can key
-	// off it without caring which collector group failed.
+	// pihole_up tracks whether a baseline auth+ping succeeded — operators
+	// can alert on this single label without caring which collector group
+	// failed underneath. Per-collector health is exposed separately as
+	// `pihole_collector_up{collector=<group>}`.
 	up := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "pihole_up",
-		Help: "1 if the Pi-hole instance was successfully scraped, 0 otherwise.",
+		Help: "1 if the Pi-hole instance was reachable and authenticated this scrape, 0 otherwise.",
 		ConstLabels: prometheus.Labels{
 			"instance": target,
 		},
 	})
 	registry.MustRegister(up)
 
-	// TODO(scaffold): wire collectors based on inst.Collectors. Until the
-	// real implementations land we just record up=0 with a debug log so
-	// the multi-target plumbing can be exercised end-to-end.
-	_ = inst
-	up.Set(0)
-	h.logger.Debug("probe (scaffold)", "target", target)
+	// Scrape-duration metric — useful for alerting on slow Pi-holes.
+	scrapeDuration := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "pihole_scrape_duration_seconds",
+		Help: "Wall-clock time spent gathering metrics for this Pi-hole instance.",
+		ConstLabels: prometheus.Labels{
+			"instance": target,
+		},
+	})
+	registry.MustRegister(scrapeDuration)
+
+	start := time.Now()
+	defer func() {
+		scrapeDuration.Set(time.Since(start).Seconds())
+	}()
+
+	// Verify the Pi-hole API is reachable + the app password still
+	// works before running the collectors. This sets pihole_up cleanly
+	// even when DNS / DHCP collectors aren't enabled.
+	pingCtx, cancel := pingCtxWithTimeout(r.Context(), pingTimeout)
+	defer cancel()
+	if err := client.Ping(pingCtx); err != nil {
+		logger.Warn("ping failed", "err", err)
+		up.Set(0)
+		promhttp.HandlerFor(registry, promhttp.HandlerOpts{}).ServeHTTP(w, r)
+		return
+	}
+	up.Set(1)
+
+	// Wire enabled collectors. DNS defaults to on; explicit false in
+	// config disables it (e.g. for an instance scraped only for DHCP
+	// metrics). DHCP collectors land in follow-up PRs.
+	if inst.Collectors.DNS == nil || *inst.Collectors.DNS {
+		registry.MustRegister(newDNSCollector(target, client, logger))
+	}
 
 	promhttp.HandlerFor(registry, promhttp.HandlerOpts{}).ServeHTTP(w, r)
+}
+
+// pingCtxWithTimeout is a thin wrapper so the probe handler can derive
+// a bounded ping context off the request's context. Pulled out so the
+// probe-handler tests can swap it out if needed.
+var pingCtxWithTimeout = func(parent context.Context, d time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, d)
 }

--- a/internal/pihole/client.go
+++ b/internal/pihole/client.go
@@ -1,0 +1,261 @@
+// Package pihole speaks Pi-hole v6's session-based REST API. The client
+// trades an "app password" (from Pi-hole's Settings → API admin page) for
+// a session ID, caches it across calls, and reauths on a 401 from a
+// stale session.
+package pihole
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// sidHeader is the HTTP header Pi-hole v6 reads for the session ID.
+// The API also accepts ?sid=… as a query parameter; the header is preferred
+// because it doesn't show up in access logs.
+const sidHeader = "X-FTL-SID"
+
+// Client is safe for concurrent use by multiple goroutines.
+type Client struct {
+	baseURL  string
+	password string
+	hc       *http.Client
+	now      func() time.Time // injectable for tests
+
+	mu     sync.Mutex
+	sid    string
+	sidExp time.Time
+}
+
+// Options configures a Client.
+type Options struct {
+	// BaseURL is the Pi-hole admin root, e.g. http://pihole.lan. The
+	// trailing /api is added by the client.
+	BaseURL string
+
+	// Password is the app-password generated under Settings → API in the
+	// Pi-hole admin UI. Pi-hole v6 trades this for a session SID.
+	Password string
+
+	// Timeout caps each upstream HTTP call.
+	Timeout time.Duration
+
+	// InsecureSkipVerify disables TLS verification for self-signed
+	// HTTPS Pi-holes. Off by default.
+	InsecureSkipVerify bool
+}
+
+// NewClient builds a Client. Validation of the URL/password is deferred
+// to the first authenticated call so config-time wiring stays simple.
+func NewClient(opts Options) *Client {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: opts.InsecureSkipVerify, //nolint:gosec // operator opt-in for self-signed Pi-holes
+			MinVersion:         tls.VersionTLS12,
+		},
+	}
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	return &Client{
+		baseURL:  strings.TrimRight(opts.BaseURL, "/"),
+		password: opts.Password,
+		hc: &http.Client{
+			Transport: transport,
+			Timeout:   timeout,
+		},
+		now: time.Now,
+	}
+}
+
+// Get fetches an API path (e.g. "/api/stats/summary") and JSON-decodes
+// the body into dst. The caller's context is honoured. A stale session
+// triggers exactly one re-auth + retry.
+func (c *Client) Get(ctx context.Context, path string, dst any) error {
+	return c.do(ctx, http.MethodGet, path, nil, dst)
+}
+
+// Ping verifies the client can authenticate without issuing a downstream
+// API call. Used by the probe handler to set pihole_up before running
+// the per-collector scrape.
+func (c *Client) Ping(ctx context.Context) error {
+	return c.ensureSession(ctx)
+}
+
+// Logout best-effort invalidates the cached session. Failures are
+// returned but don't affect the cache (Pi-hole sessions also age out
+// server-side, so a client crash isn't catastrophic).
+func (c *Client) Logout(ctx context.Context) error {
+	c.mu.Lock()
+	sid := c.sid
+	c.mu.Unlock()
+	if sid == "" {
+		return nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/api/auth", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set(sidHeader, sid)
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	c.mu.Lock()
+	c.sid = ""
+	c.sidExp = time.Time{}
+	c.mu.Unlock()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("logout: HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body io.Reader, dst any) error {
+	if err := c.ensureSession(ctx); err != nil {
+		return err
+	}
+
+	if err := c.attempt(ctx, method, path, body, dst); err != nil {
+		// One re-auth + retry on a stale session. Pi-hole returns 401
+		// with `{"session":{"valid":false,…}}` when the SID has aged out;
+		// attempt() reports that as errStaleSession.
+		if errors.Is(err, errStaleSession) {
+			if err := c.refreshSession(ctx); err != nil {
+				return err
+			}
+			return c.attempt(ctx, method, path, body, dst)
+		}
+		return err
+	}
+	return nil
+}
+
+// attempt performs a single round-trip + decode. The caller handles
+// auth-retry semantics. Splitting this out makes body-close tracking
+// trivial: each call owns exactly one response and closes it.
+func (c *Client) attempt(ctx context.Context, method, path string, body io.Reader, dst any) error {
+	resp, err := c.execute(ctx, method, path, body)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return errStaleSession
+	}
+	if resp.StatusCode >= 400 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("pihole %s %s: HTTP %d: %s", method, path, resp.StatusCode, bytes.TrimSpace(snippet))
+	}
+	if dst == nil {
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
+		return fmt.Errorf("decode %s: %w", path, err)
+	}
+	return nil
+}
+
+// errStaleSession is the internal signal that triggers reauth-and-retry
+// inside Client.do.
+var errStaleSession = errors.New("pihole: session stale")
+
+func (c *Client) execute(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
+	if err != nil {
+		return nil, err
+	}
+	c.mu.Lock()
+	sid := c.sid
+	c.mu.Unlock()
+	if sid != "" {
+		req.Header.Set(sidHeader, sid)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+	return c.hc.Do(req)
+}
+
+// ensureSession returns nil if a non-expired session is already cached,
+// otherwise authenticates with the configured app password.
+func (c *Client) ensureSession(ctx context.Context) error {
+	c.mu.Lock()
+	fresh := c.sid != "" && c.now().Before(c.sidExp.Add(-30*time.Second))
+	c.mu.Unlock()
+	if fresh {
+		return nil
+	}
+	return c.refreshSession(ctx)
+}
+
+func (c *Client) refreshSession(ctx context.Context) error {
+	if c.password == "" {
+		return errors.New("pihole: app password is empty")
+	}
+	body, err := json.Marshal(map[string]string{"password": c.password})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/auth", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("auth: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("auth: HTTP %d: %s", resp.StatusCode, bytes.TrimSpace(snippet))
+	}
+
+	var ar authResponse
+	if err := json.NewDecoder(resp.Body).Decode(&ar); err != nil {
+		return fmt.Errorf("auth: decode: %w", err)
+	}
+	if !ar.Session.Valid || ar.Session.SID == "" {
+		return fmt.Errorf("auth: rejected: %s", ar.Session.Message)
+	}
+
+	validity := time.Duration(ar.Session.Validity) * time.Second
+	if validity <= 0 {
+		validity = 5 * time.Minute
+	}
+	c.mu.Lock()
+	c.sid = ar.Session.SID
+	c.sidExp = c.now().Add(validity)
+	c.mu.Unlock()
+	return nil
+}
+
+// authResponse mirrors POST /api/auth.
+type authResponse struct {
+	Session struct {
+		Valid    bool   `json:"valid"`
+		TOTP     bool   `json:"totp"`
+		SID      string `json:"sid"`
+		CSRF     string `json:"csrf"`
+		Validity int    `json:"validity"`
+		Message  string `json:"message"`
+	} `json:"session"`
+	Took float64 `json:"took"`
+}

--- a/internal/pihole/client_test.go
+++ b/internal/pihole/client_test.go
@@ -1,0 +1,146 @@
+package pihole
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestClient_Auth_Success(t *testing.T) {
+	t.Parallel()
+
+	var authCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/auth":
+			authCalls.Add(1)
+			var body struct {
+				Password string `json:"password"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if body.Password != "secret" {
+				http.Error(w, `{"session":{"valid":false,"message":"bad password"}}`, http.StatusUnauthorized)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(authResponse{Session: struct {
+				Valid    bool   `json:"valid"`
+				TOTP     bool   `json:"totp"`
+				SID      string `json:"sid"`
+				CSRF     string `json:"csrf"`
+				Validity int    `json:"validity"`
+				Message  string `json:"message"`
+			}{Valid: true, SID: "S1", Validity: 1800}})
+		case "/api/stats/summary":
+			if r.Header.Get(sidHeader) != "S1" {
+				http.Error(w, "missing SID", http.StatusUnauthorized)
+				return
+			}
+			_, _ = w.Write([]byte(`{"queries":{"total":42}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(Options{BaseURL: srv.URL, Password: "secret", Timeout: 2 * time.Second})
+
+	var summary StatsSummary
+	if err := c.Get(context.Background(), "/api/stats/summary", &summary); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if summary.Queries.Total != 42 {
+		t.Fatalf("queries.total = %d, want 42", summary.Queries.Total)
+	}
+
+	// Second call should reuse the session, not re-auth.
+	if err := c.Get(context.Background(), "/api/stats/summary", &summary); err != nil {
+		t.Fatalf("Get (cached): %v", err)
+	}
+	if got := authCalls.Load(); got != 1 {
+		t.Fatalf("auth was called %d times, want 1 (session should be cached)", got)
+	}
+}
+
+func TestClient_ReauthOn401(t *testing.T) {
+	t.Parallel()
+
+	var authCalls atomic.Int32
+	var statsCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/auth":
+			n := authCalls.Add(1)
+			sid := "S1"
+			if n == 2 {
+				sid = "S2"
+			}
+			_ = json.NewEncoder(w).Encode(authResponse{Session: struct {
+				Valid    bool   `json:"valid"`
+				TOTP     bool   `json:"totp"`
+				SID      string `json:"sid"`
+				CSRF     string `json:"csrf"`
+				Validity int    `json:"validity"`
+				Message  string `json:"message"`
+			}{Valid: true, SID: sid, Validity: 1800}})
+		case "/api/stats/summary":
+			n := statsCalls.Add(1)
+			// First request: session has aged out → 401.
+			// Second request (after re-auth): accept S2.
+			switch {
+			case n == 1:
+				http.Error(w, `{"session":{"valid":false}}`, http.StatusUnauthorized)
+			case r.Header.Get(sidHeader) == "S2":
+				_, _ = w.Write([]byte(`{"queries":{"total":7}}`))
+			default:
+				http.Error(w, "wrong sid", http.StatusUnauthorized)
+			}
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(Options{BaseURL: srv.URL, Password: "secret", Timeout: 2 * time.Second})
+
+	var summary StatsSummary
+	if err := c.Get(context.Background(), "/api/stats/summary", &summary); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if summary.Queries.Total != 7 {
+		t.Fatalf("queries.total = %d, want 7", summary.Queries.Total)
+	}
+	if got := authCalls.Load(); got != 2 {
+		t.Fatalf("auth was called %d times, want 2 (initial + reauth)", got)
+	}
+}
+
+func TestClient_AuthRejected(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"session":{"valid":false,"message":"bad password"}}`, http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := NewClient(Options{BaseURL: srv.URL, Password: "wrong"})
+	err := c.Get(context.Background(), "/api/stats/summary", &StatsSummary{})
+	if err == nil {
+		t.Fatal("expected auth error, got nil")
+	}
+	if !strings.Contains(err.Error(), "auth") {
+		t.Fatalf("expected auth error, got %v", err)
+	}
+}
+
+func TestClient_EmptyPassword(t *testing.T) {
+	t.Parallel()
+
+	c := NewClient(Options{BaseURL: "http://127.0.0.1:1", Password: ""})
+	err := c.Get(context.Background(), "/api/stats/summary", &StatsSummary{})
+	if err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("expected empty-password error, got %v", err)
+	}
+}

--- a/internal/pihole/doc.go
+++ b/internal/pihole/doc.go
@@ -1,7 +1,0 @@
-// Package pihole holds the Pi-hole v6 REST API client used by the DNS
-// collector group. The client handles app-password → SID exchange, session
-// reuse, and reauth on 401.
-//
-// Implementation lands in a follow-up PR. This package exists at scaffold
-// time so the rest of the layout has a stable import home.
-package pihole

--- a/internal/pihole/types.go
+++ b/internal/pihole/types.go
@@ -1,0 +1,136 @@
+package pihole
+
+// StatsSummary mirrors GET /api/stats/summary.
+//
+// All Pi-hole "today" counters reset at midnight server-time, which
+// rate()/increase() handle as ordinary counter resets.
+type StatsSummary struct {
+	Queries struct {
+		Total          int64            `json:"total"`
+		Blocked        int64            `json:"blocked"`
+		PercentBlocked float64          `json:"percent_blocked"`
+		UniqueDomains  int64            `json:"unique_domains"`
+		Forwarded      int64            `json:"forwarded"`
+		Cached         int64            `json:"cached"`
+		Frequency      float64          `json:"frequency"`
+		Types          map[string]int64 `json:"types"`
+		Status         map[string]int64 `json:"status"`
+		Replies        map[string]int64 `json:"replies"`
+	} `json:"queries"`
+	Clients struct {
+		Active int64 `json:"active"`
+		Total  int64 `json:"total"`
+	} `json:"clients"`
+	Gravity struct {
+		DomainsBeingBlocked int64 `json:"domains_being_blocked"`
+		LastUpdate          int64 `json:"last_update"`
+	} `json:"gravity"`
+	Took float64 `json:"took"`
+}
+
+// StatsUpstreams mirrors GET /api/stats/upstreams.
+type StatsUpstreams struct {
+	Upstreams []struct {
+		IP         string `json:"ip"`
+		Name       string `json:"name"`
+		Port       int    `json:"port"`
+		Count      int64  `json:"count"`
+		Statistics struct {
+			Response float64 `json:"response"`
+			Variance float64 `json:"variance"`
+		} `json:"statistics"`
+	} `json:"upstreams"`
+	ForwardedQueries int64   `json:"forwarded_queries"`
+	TotalQueries     int64   `json:"total_queries"`
+	Took             float64 `json:"took"`
+}
+
+// InfoVersion mirrors GET /api/info/version. Pi-hole reports each
+// component's version as a struct with local + remote sides; the
+// exporter only consumes the local versions for an info-style metric.
+type InfoVersion struct {
+	Version struct {
+		Core struct {
+			Local versionLocal `json:"local"`
+		} `json:"core"`
+		FTL struct {
+			Local versionLocal `json:"local"`
+		} `json:"ftl"`
+		Web struct {
+			Local versionLocal `json:"local"`
+		} `json:"web"`
+	} `json:"version"`
+	Took float64 `json:"took"`
+}
+
+type versionLocal struct {
+	Version string `json:"version"`
+	Branch  string `json:"branch"`
+	Hash    string `json:"hash"`
+}
+
+// CoreVersion / FTLVersion / WebVersion expose just the local version
+// strings, defaulting to "unknown" when Pi-hole hasn't populated the
+// component (e.g. during a partial upgrade).
+func (v InfoVersion) CoreVersion() string { return orUnknown(v.Version.Core.Local.Version) }
+func (v InfoVersion) FTLVersion() string  { return orUnknown(v.Version.FTL.Local.Version) }
+func (v InfoVersion) WebVersion() string  { return orUnknown(v.Version.Web.Local.Version) }
+
+func orUnknown(s string) string {
+	if s == "" {
+		return "unknown"
+	}
+	return s
+}
+
+// InfoFTL mirrors GET /api/info/ftl. Only the fields the exporter maps
+// to metrics today are decoded; unknown fields are dropped by
+// json.Unmarshal so adding more is purely additive.
+type InfoFTL struct {
+	FTL struct {
+		Database struct {
+			Gravity int64 `json:"gravity"`
+			Groups  int64 `json:"groups"`
+			Lists   int64 `json:"lists"`
+			Clients int64 `json:"clients"`
+			Domains struct {
+				Allowed int64 `json:"allowed"`
+				Denied  int64 `json:"denied"`
+			} `json:"domains"`
+		} `json:"database"`
+		PrivacyLevel int `json:"privacy_level"`
+		Clients      struct {
+			Total  int64 `json:"total"`
+			Active int64 `json:"active"`
+		} `json:"clients"`
+		MemPercent float64 `json:"%mem"`
+		CPUPercent float64 `json:"%cpu"`
+		DNSMasq    struct {
+			DNSCacheInserted     int64 `json:"dns_cache_inserted"`
+			DNSCacheLiveFreed    int64 `json:"dns_cache_live_freed"`
+			DNSQueriesForwarded  int64 `json:"dns_queries_forwarded"`
+			DNSAuthAnswered      int64 `json:"dns_auth_answered"`
+			DNSLocalAnswered     int64 `json:"dns_local_answered"`
+			DNSStaleAnswered     int64 `json:"dns_stale_answered"`
+			DNSUnansweredQueries int64 `json:"dns_unanswered_queries"`
+		} `json:"dnsmasq"`
+		Type string `json:"type"`
+	} `json:"ftl"`
+	Took float64 `json:"took"`
+}
+
+// DNSBlocking mirrors GET /api/dns/blocking. The string field is one
+// of "enabled", "disabled", "failed", "unknown".
+type DNSBlocking struct {
+	Blocking string  `json:"blocking"`
+	Timer    *int    `json:"timer"`
+	Took     float64 `json:"took"`
+}
+
+// Enabled returns 1 when blocking is in the "enabled" state, 0 otherwise.
+func (b DNSBlocking) Enabled() float64 {
+	if b.Blocking == "enabled" {
+		return 1
+	}
+	return 0
+}


### PR DESCRIPTION
## Summary

Carries the scaffold from `fabc1e6` to a usable DNS exporter: real Pi-hole v6 client + the first collector group.

## What's in

### `internal/pihole`
- `client.go` — session-based auth (app-password → SID), TTL-aware session cache, one-shot reauth on stale-session `401`, body-close hygiene, optional `InsecureSkipVerify` for self-signed Pi-holes. `Get()`, `Ping()`, `Logout()` are the public surface.
- `types.go` — typed views of `/api/stats/summary`, `/api/stats/upstreams`, `/api/dns/blocking`, `/api/info/ftl`, `/api/info/version`. Unknown JSON fields are silently dropped, so additive Pi-hole API changes don't break the build.
- `client_test.go` — `httptest.Server` tables for: auth success + session cache reuse, reauth on stale 401, auth rejection on bad password, empty-password short-circuit.

### `internal/exporter`
- `dns.go` — DNS collector that emits ~30 metrics covering queries (total / blocked / forwarded / cached / by-type / by-status / by-reply / blocked-ratio / per-second / unique-domains), clients, gravity, per-upstream stats, blocking state, FTL runtime, dnsmasq counters, info gauge, per-collector health.
- `probe.go` — wires the DNS collector when enabled in config. Adds `pihole_up` (gated on an explicit `Ping()` before any collector runs, so it cleanly reflects auth health) and `pihole_scrape_duration_seconds`. Per-instance `*pihole.Client`s are created once and reused across scrapes so the SID stays cached.
- `dns_test.go` — table-driven tests with a `fakePihole` that handles auth + steers per-path JSON.

## Counter semantics note

Pi-hole's \"today\" counters reset at midnight server-time. They're modeled as Prometheus counters anyway because rate() / increase() handle the reset cleanly as ordinary counter restarts. HELP strings call this out so operators aren't surprised.

## Verification

- go test -race ./… green on both packages.
- golangci-lint clean.
- gofmt -s clean.
- End-to-end smoke: built the binary, ran it against a fake Pi-hole on 127.0.0.1:18080, hit /probe?target=fake — got back the expected pihole_* metrics including pihole_up=1, the per-collector health gauge, and version info; bad target returns 404; /metrics still serves only exporter-self metrics.

## Out of scope (next PRs)

- DHCP leases collector (separate PR)
- DHCP log collector (separate PR)
- v0.1.0 release tag once all three are in