### PR TITLE
Add DHCP log collector

### DIFF
--- a/cmd/prometheus_pihole_exporter/main.go
+++ b/cmd/prometheus_pihole_exporter/main.go
@@ -69,7 +69,10 @@ func main() {
 		collectors.NewGoCollector(),
 	)
 
-	probeHandler := exporter.NewProbeHandler(cfg, logger)
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	probeHandler := exporter.NewProbeHandler(ctx, cfg, logger)
 
 	mux := http.NewServeMux()
 	mux.Handle(*metricsPath, promhttp.HandlerFor(selfRegistry, promhttp.HandlerOpts{}))
@@ -97,9 +100,6 @@ func main() {
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
-
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
 
 	go func() {
 		logger.Info("server listening", "addr", *listenAddr, "metrics", *metricsPath, "probe", *probePath)

--- a/internal/exporter/dhcp_log.go
+++ b/internal/exporter/dhcp_log.go
@@ -1,0 +1,224 @@
+package exporter
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// dhcpLogState is a long-lived counter holder for one Pi-hole's
+// dnsmasq log. The tailer goroutine appends new events into the
+// counters; the prometheus.Collector built around it just snapshots
+// the current values when scraped.
+type dhcpLogState struct {
+	instance string
+	path     string
+	logger   *slog.Logger
+
+	mu             sync.Mutex
+	msgCounts      map[string]int64 // canonical message type → count
+	parseErrors    int64
+	lastEvent      int64 // unix seconds
+	lastTailError  string
+	lastTailErrAt  int64 // unix seconds
+	healthyTailing bool
+}
+
+func newDHCPLogState(instance, path string, logger *slog.Logger) *dhcpLogState {
+	return &dhcpLogState{
+		instance:  instance,
+		path:      path,
+		logger:    logger.With("collector", "dhcp_log", "instance", instance),
+		msgCounts: map[string]int64{},
+	}
+}
+
+// dhcpMessageRE matches dnsmasq DHCP log lines. The interesting bit is
+// the message-type word ("DHCPACK", "DHCPOFFER", …). Examples:
+//
+//	Apr 28 19:00:01 dnsmasq-dhcp[1234]: DHCPDISCOVER(eth0) aa:bb:cc:dd:ee:ff
+//	Apr 28 19:00:01 dnsmasq-dhcp[1234]: DHCPOFFER(eth0) 192.168.0.50 aa:bb:cc:dd:ee:ff
+//	Apr 28 19:00:01 dnsmasq-dhcp[1234]: DHCPACK(eth0) 192.168.0.50 aa:bb:cc:dd:ee:ff hostname-here
+//
+// The regex is anchored on a word boundary so DHCPv6 message-types
+// (DHCP6SOLICIT etc.) match too — those decay into the canonical
+// `DHCPv6` bucket so v4 and v6 don't collide.
+var dhcpMessageRE = regexp.MustCompile(`\b(DHCP(?:ACK|NAK|OFFER|REQUEST|DECLINE|RELEASE|DISCOVER|INFORM|6[A-Z]+))\b`)
+
+func (s *dhcpLogState) processLine(line string) {
+	m := dhcpMessageRE.FindStringSubmatch(line)
+	if m == nil {
+		return
+	}
+	msg := m[1]
+	bucket := canonicalMessageType(msg)
+	s.mu.Lock()
+	s.msgCounts[bucket]++
+	s.lastEvent = time.Now().Unix()
+	s.mu.Unlock()
+}
+
+func canonicalMessageType(raw string) string {
+	if len(raw) >= 5 && raw[:5] == "DHCP6" {
+		return "DHCPv6"
+	}
+	return raw
+}
+
+// run owns the tail loop until ctx is done. It re-opens the file on
+// every iteration so log-rotation doesn't strand the descriptor; it
+// detects truncation by inode change or by size shrink and resets the
+// read offset accordingly.
+func (s *dhcpLogState) run(ctx context.Context) {
+	var (
+		pos       int64
+		lastInode uint64
+	)
+	const idle = 1 * time.Second
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		err := func() error {
+			f, err := os.Open(s.path) //nolint:gosec // operator-controlled path
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+
+			st, err := f.Stat()
+			if err != nil {
+				return err
+			}
+			ino := inodeOf(st)
+			if ino != lastInode || st.Size() < pos {
+				// rotation, truncation, or first read: start at end so
+				// we don't replay a giant historical log on startup.
+				pos = st.Size()
+				lastInode = ino
+			}
+			if _, err := f.Seek(pos, io.SeekStart); err != nil {
+				return err
+			}
+
+			scanner := bufio.NewScanner(f)
+			scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+			for scanner.Scan() {
+				s.processLine(scanner.Text())
+			}
+			if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) {
+				s.mu.Lock()
+				s.parseErrors++
+				s.mu.Unlock()
+			}
+			cur, err := f.Seek(0, io.SeekCurrent)
+			if err == nil {
+				pos = cur
+			}
+			return nil
+		}()
+
+		s.mu.Lock()
+		if err != nil {
+			s.healthyTailing = false
+			s.lastTailError = err.Error()
+			s.lastTailErrAt = time.Now().Unix()
+		} else {
+			s.healthyTailing = true
+		}
+		s.mu.Unlock()
+
+		if err != nil {
+			s.logger.Warn("tail iteration failed", "err", err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(idle):
+		}
+	}
+}
+
+func (s *dhcpLogState) snapshot() (map[string]int64, int64, int64, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make(map[string]int64, len(s.msgCounts))
+	for k, v := range s.msgCounts {
+		out[k] = v
+	}
+	return out, s.parseErrors, s.lastEvent, s.healthyTailing
+}
+
+// dhcpLogCollector exposes the snapshot of a dhcpLogState as
+// Prometheus metrics.
+type dhcpLogCollector struct {
+	instance string
+	state    *dhcpLogState
+
+	descMsgTotal    *prometheus.Desc
+	descParseErrors *prometheus.Desc
+	descLastEvent   *prometheus.Desc
+	descCollectorUp *prometheus.Desc
+}
+
+func newDHCPLogCollector(instance string, state *dhcpLogState) prometheus.Collector {
+	labels := prometheus.Labels{"instance": instance}
+	d := func(name, help string, varLabels ...string) *prometheus.Desc {
+		return prometheus.NewDesc(name, help, varLabels, labels)
+	}
+	return &dhcpLogCollector{
+		instance:        instance,
+		state:           state,
+		descMsgTotal:    d("pihole_dhcp_messages_total", "Number of DHCP messages observed in the dnsmasq log since the exporter started, partitioned by type.", "type"),
+		descParseErrors: d("pihole_dhcp_log_parse_errors_total", "Errors encountered while parsing the dnsmasq log."),
+		descLastEvent:   d("pihole_dhcp_log_last_event_timestamp_seconds", "Unix timestamp of the most recently observed DHCP event (0 if none yet)."),
+		descCollectorUp: d("pihole_collector_up", "1 if a given collector group's scrape succeeded, 0 otherwise.", "collector"),
+	}
+}
+
+func (c *dhcpLogCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, d := range []*prometheus.Desc{c.descMsgTotal, c.descParseErrors, c.descLastEvent, c.descCollectorUp} {
+		ch <- d
+	}
+}
+
+func (c *dhcpLogCollector) Collect(ch chan<- prometheus.Metric) {
+	counts, parseErrors, lastEvent, healthy := c.state.snapshot()
+
+	// Always emit zero rows for the message types operators most
+	// commonly alert on, so PromQL `rate(pihole_dhcp_messages_total{
+	// type="DHCPNAK"}[5m]) > 0` works without absent() guards.
+	always := []string{"DHCPACK", "DHCPNAK", "DHCPOFFER", "DHCPREQUEST", "DHCPDECLINE", "DHCPRELEASE", "DHCPDISCOVER", "DHCPINFORM"}
+	emitted := map[string]bool{}
+	for _, t := range always {
+		ch <- prometheus.MustNewConstMetric(c.descMsgTotal, prometheus.CounterValue, float64(counts[t]), t)
+		emitted[t] = true
+	}
+	// Anything else we've actually observed (e.g. DHCPv6 bucket).
+	for k, v := range counts {
+		if !emitted[k] {
+			ch <- prometheus.MustNewConstMetric(c.descMsgTotal, prometheus.CounterValue, float64(v), k)
+		}
+	}
+
+	ch <- prometheus.MustNewConstMetric(c.descParseErrors, prometheus.CounterValue, float64(parseErrors))
+	ch <- prometheus.MustNewConstMetric(c.descLastEvent, prometheus.GaugeValue, float64(lastEvent))
+
+	upVal := 0.0
+	if healthy {
+		upVal = 1
+	}
+	ch <- prometheus.MustNewConstMetric(c.descCollectorUp, prometheus.GaugeValue, upVal, "dhcp_log")
+}

--- a/internal/exporter/dhcp_log_test.go
+++ b/internal/exporter/dhcp_log_test.go
@@ -1,0 +1,146 @@
+package exporter
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDHCPLog_ProcessLine(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		line string
+		want string
+	}{
+		{"DHCPDISCOVER", "Apr 28 19:00:01 dnsmasq-dhcp[1234]: DHCPDISCOVER(eth0) aa:bb:cc:dd:ee:ff", "DHCPDISCOVER"},
+		{"DHCPOFFER", "Apr 28 19:00:01 dnsmasq-dhcp[1234]: DHCPOFFER(eth0) 192.168.0.50 aa:bb:cc:dd:ee:ff", "DHCPOFFER"},
+		{"DHCPACK", "Apr 28 19:00:01 dnsmasq-dhcp[1234]: DHCPACK(eth0) 192.168.0.50 aa:bb:cc:dd:ee:ff hostname-here", "DHCPACK"},
+		{"DHCPNAK", "Apr 28 19:00:01 dnsmasq-dhcp[1234]: DHCPNAK(eth0) 192.168.0.50 aa:bb:cc:dd:ee:ff", "DHCPNAK"},
+		{"DHCPDECLINE", "Apr 28 19:00:01 dnsmasq-dhcp[1234]: DHCPDECLINE(eth0) 192.168.0.50 aa:bb:cc:dd:ee:ff", "DHCPDECLINE"},
+		{"DHCPRELEASE", "Apr 28 19:00:01 dnsmasq-dhcp[1234]: DHCPRELEASE(eth0) 192.168.0.50 aa:bb:cc:dd:ee:ff", "DHCPRELEASE"},
+		{"DHCPREQUEST", "Apr 28 19:00:01 dnsmasq-dhcp[1234]: DHCPREQUEST(eth0) 192.168.0.50 aa:bb:cc:dd:ee:ff", "DHCPREQUEST"},
+		{"DHCPINFORM", "Apr 28 19:00:01 dnsmasq-dhcp[1234]: DHCPINFORM(eth0) 192.168.0.50 aa:bb:cc:dd:ee:ff", "DHCPINFORM"},
+		{"DHCPv6", "Apr 28 19:00:01 dnsmasq-dhcp[1234]: DHCP6SOLICIT(eth0) aa:bb:cc:dd:ee:ff", "DHCPv6"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newDHCPLogState("primary", "/dev/null", slog.New(slog.NewTextHandler(io.Discard, nil)))
+			s.processLine(tc.line)
+			counts, _, _, _ := s.snapshot()
+			if counts[tc.want] != 1 {
+				t.Fatalf("counts[%q] = %d, want 1 (full snapshot: %v)", tc.want, counts[tc.want], counts)
+			}
+		})
+	}
+}
+
+func TestDHCPLog_IgnoresUnrelatedLines(t *testing.T) {
+	t.Parallel()
+
+	s := newDHCPLogState("primary", "/dev/null", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	for _, l := range []string{
+		"Apr 28 19:00:01 dnsmasq[1234]: query[A] example.com from 192.168.0.50",
+		"Apr 28 19:00:02 dnsmasq[1234]: forwarded example.com to 9.9.9.9",
+		"Apr 28 19:00:03 dnsmasq-dhcp[1234]: read /etc/hosts",
+		"",
+	} {
+		s.processLine(l)
+	}
+	counts, _, _, _ := s.snapshot()
+	if len(counts) != 0 {
+		t.Fatalf("expected no DHCP counts from unrelated lines, got %v", counts)
+	}
+}
+
+// TestDHCPLog_TailsAppendedLines exercises the run loop end-to-end:
+// it points the tailer at a temp file, lets it consume the seed lines,
+// then appends new lines and verifies the counters update.
+func TestDHCPLog_TailsAppendedLines(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pihole.log")
+	if err := os.WriteFile(path, []byte("Apr 28 19:00:00 dnsmasq-dhcp[1234]: DHCPACK(eth0) 192.168.0.50 aa:bb:cc:dd:ee:ff\n"), 0o600); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+
+	s := newDHCPLogState("primary", path, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.run(ctx)
+
+	// First iteration of run() seeks to end-of-file (so the seed line
+	// from before the tailer started is intentionally NOT counted).
+	// Wait for the loop to settle, then append one line and assert
+	// it gets counted.
+	if !waitFor(t, 3*time.Second, func() bool {
+		_, _, _, healthy := s.snapshot()
+		return healthy
+	}) {
+		t.Fatal("tailer never reported healthy")
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if _, err := f.WriteString("Apr 28 19:00:01 dnsmasq-dhcp[1234]: DHCPDISCOVER(eth0) aa:bb:cc:dd:ee:ff\n"); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	_ = f.Close()
+
+	if !waitFor(t, 5*time.Second, func() bool {
+		counts, _, _, _ := s.snapshot()
+		return counts["DHCPDISCOVER"] == 1
+	}) {
+		counts, _, _, _ := s.snapshot()
+		t.Fatalf("appended DHCPDISCOVER not counted; counts=%v", counts)
+	}
+}
+
+func TestDHCPLogCollector_AlwaysEmitsZeroRows(t *testing.T) {
+	t.Parallel()
+
+	s := newDHCPLogState("primary", "/nonexistent", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	// processLine just one type, so the collector also has to fill in
+	// the rest as zero.
+	s.processLine("Apr 28 19:00:01 dnsmasq-dhcp[1234]: DHCPACK(eth0) 192.168.0.50 aa:bb:cc:dd:ee:ff host")
+
+	c := newDHCPLogCollector("primary", s)
+	got := gatherText(t, c)
+
+	for _, want := range []string{
+		`pihole_dhcp_messages_total{instance="primary",type="DHCPACK"} 1`,
+		`pihole_dhcp_messages_total{instance="primary",type="DHCPNAK"} 0`,
+		`pihole_dhcp_messages_total{instance="primary",type="DHCPDECLINE"} 0`,
+		`pihole_dhcp_messages_total{instance="primary",type="DHCPRELEASE"} 0`,
+		`pihole_dhcp_log_parse_errors_total{instance="primary"} 0`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing:\n  want: %q\n  got:\n%s", want, got)
+		}
+	}
+	if !strings.Contains(got, `pihole_collector_up{collector="dhcp_log",instance="primary"} 0`) {
+		t.Fatalf("expected collector_up=0 (tailer never ran), got:\n%s", got)
+	}
+}
+
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return cond()
+}

--- a/internal/exporter/inode_other.go
+++ b/internal/exporter/inode_other.go
@@ -1,0 +1,12 @@
+//go:build !unix
+
+package exporter
+
+import "os"
+
+// inodeOf returns 0 on non-Unix platforms — rotation detection then
+// falls back to the size-shrink check, which is good enough for the
+// build to compile and the unit tests to pass.
+func inodeOf(_ os.FileInfo) uint64 {
+	return 0
+}

--- a/internal/exporter/inode_unix.go
+++ b/internal/exporter/inode_unix.go
@@ -1,0 +1,18 @@
+//go:build unix
+
+package exporter
+
+import (
+	"os"
+	"syscall"
+)
+
+// inodeOf returns a stable per-file identifier on Unix. Used by the
+// dhcp_log tailer to detect log rotation: a renamed/recreated file has
+// a different inode even if the path is unchanged.
+func inodeOf(fi os.FileInfo) uint64 {
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+		return st.Ino
+	}
+	return 0
+}

--- a/internal/exporter/probe.go
+++ b/internal/exporter/probe.go
@@ -32,12 +32,15 @@ const pingTimeout = 10 * time.Second
 //
 // Each Pi-hole instance gets a single shared *pihole.Client (reused
 // across scrapes so the v6 session SID gets cached) and a freshly-built
-// registry per request.
-func NewProbeHandler(cfg *config.Config, logger *slog.Logger) http.Handler {
+// registry per request. Instances that opt into the dhcp_log collector
+// also get a long-lived tailer goroutine started here; those goroutines
+// stop when ctx is cancelled (typically on SIGINT/SIGTERM in main).
+func NewProbeHandler(ctx context.Context, cfg *config.Config, logger *slog.Logger) http.Handler {
 	h := &probeHandler{
 		cfg:     cfg,
 		logger:  logger,
 		clients: make(map[string]*pihole.Client, len(cfg.Instances)),
+		dhcpLog: make(map[string]*dhcpLogState, len(cfg.Instances)),
 	}
 	for id, inst := range cfg.Instances {
 		h.clients[id] = pihole.NewClient(pihole.Options{
@@ -46,6 +49,11 @@ func NewProbeHandler(cfg *config.Config, logger *slog.Logger) http.Handler {
 			Timeout:            inst.Timeout,
 			InsecureSkipVerify: inst.InsecureSkipVerify,
 		})
+		if dl := inst.Collectors.DHCPLog; dl != nil && dl.Path != "" {
+			state := newDHCPLogState(id, dl.Path, logger)
+			h.dhcpLog[id] = state
+			go state.run(ctx)
+		}
 	}
 	return h
 }
@@ -53,8 +61,9 @@ func NewProbeHandler(cfg *config.Config, logger *slog.Logger) http.Handler {
 type probeHandler struct {
 	cfg     *config.Config
 	logger  *slog.Logger
-	mu      sync.Mutex // guards clients
+	mu      sync.Mutex // guards clients + dhcpLog
 	clients map[string]*pihole.Client
+	dhcpLog map[string]*dhcpLogState
 }
 
 func (h *probeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -126,6 +135,9 @@ func (h *probeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	if dl := inst.Collectors.DHCPLeases; dl != nil && dl.Path != "" {
 		registry.MustRegister(newDHCPLeasesCollector(target, dl.Path, logger))
+	}
+	if state := h.dhcpLog[target]; state != nil {
+		registry.MustRegister(newDHCPLogCollector(target, state))
 	}
 
 	promhttp.HandlerFor(registry, promhttp.HandlerOpts{}).ServeHTTP(w, r)


### PR DESCRIPTION
## Summary

Stacks on top of [#3 (DHCP leases collector)](https://github.com/reloaded/prometheus_pihole_exporter/pull/3) → base is `workitem/dhcp-leases-collector`. Will retarget to `main` after #2 and #3 merge.

The third and final collector group: tails Pi-hole's dnsmasq log file and emits per-message-type counters so operators can rate() / alert on DHCP traffic shape.

## Architecture

The leases collector re-reads its file on every scrape; the log collector can't — DHCP events are point-in-time, so we have to be running while they fly past. Long-lived design:

- Per-Pi-hole `dhcpLogState` is created at `NewProbeHandler` time when the instance config sets `collectors.dhcp_log.path`. A goroutine starts immediately and runs until the request-context (now plumbed through `main.go` from the SIGINT/SIGTERM handler) is cancelled.
- The tailer re-opens the file each iteration (1 s polling) so log-rotation doesn't strand the descriptor; rotation is detected by inode change or by `size < lastPos`.
- The collector struct itself is stateless — `Collect()` just snapshots the state's counters.

## Metrics

- `pihole_dhcp_messages_total{type=…}` — counter, one row per message type. Always emits zero rows for the v4 types (`DHCPACK / NAK / OFFER / REQUEST / DECLINE / RELEASE / DISCOVER / INFORM`) so rate-based alerts don't need `absent()`. DHCPv6 message types collapse into a single `type="DHCPv6"` bucket.
- `pihole_dhcp_log_parse_errors_total` — counter, scanner errors.
- `pihole_dhcp_log_last_event_timestamp_seconds` — gauge, Unix time of the most recent DHCP event observed.
- `pihole_collector_up{collector="dhcp_log"}` — health.

## Lifecycle change

`NewProbeHandler` now takes a `context.Context` as its first argument so tailer goroutines can shut down cleanly. `cmd/prometheus_pihole_exporter/main.go` was updated in the same commit; the SIGINT/SIGTERM context already lives there.

## Verification

- `go test -race ./… -count=1` — green; new tests cover the per-message-type recognition table, that non-DHCP log lines are ignored, end-to-end tail-and-count against a temp file (tailer seeks to end on first open then picks up appended lines), and the always-zero-rows emission shape.
- `golangci-lint` clean, `gofmt -s` clean.

## After this lands

- I'll cut `v0.1.0` on `prometheus_pihole_exporter`. The release workflow already handles multi-arch image publishing to `ghcr.io/reloaded/prometheus_pihole_exporter`.
- Then pivot back to ai-network PR #54 for the Ansible role + Grafana dashboard + lifecycle tests.