### PR TITLE
Add CLI / env overrides for collector toggles (closes #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ Configuration is YAML. See [`examples/config.yaml`](examples/config.yaml)
 for the full shape. App-passwords are not stored inline — each instance
 names an env var that the exporter reads at scrape time.
 
+### Collector overrides (CLI / env)
+
+Each Pi-hole instance enables collector groups via its `collectors:` block
+in YAML, but a deploy-time global override is also available so a collector
+can be flipped on or off across every instance without editing the config
+file. Useful when rolling a collector out gradually, or silencing one for
+an investigation.
+
+| Flag                     | Env                                       | Effect when set                                                                                                                                                      |
+| ------------------------ | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-collector.dns`         | `PIHOLE_EXPORTER_COLLECTOR_DNS`           | Force the DNS collector on (`true`) or off (`false`) for every instance.                                                                                             |
+| `-collector.dhcp-leases` | `PIHOLE_EXPORTER_COLLECTOR_DHCP_LEASES`   | Force the DHCP-leases collector on/off. Truthy values still require `collectors.dhcp_leases.path` per instance — the override doesn't synthesise paths.              |
+| `-collector.dhcp-log`    | `PIHOLE_EXPORTER_COLLECTOR_DHCP_LOG`      | Force the DHCP-log collector on/off, same "still needs the YAML path" rule.                                                                                          |
+
+Precedence (highest first): **CLI flag → env var → per-instance YAML → built-in default**. Empty/unset means "don't override" and the YAML's view stands.
+
 ## Running
 
 ### Container

--- a/cmd/prometheus_pihole_exporter/main.go
+++ b/cmd/prometheus_pihole_exporter/main.go
@@ -45,6 +45,7 @@ func main() {
 		probePath   = flag.String("web.probe-path", envOr("PIHOLE_EXPORTER_PROBE_PATH", "/probe"), "Path under which per-instance probe metrics are served.")
 		showVersion = flag.Bool("version", false, "Print version information and exit.")
 	)
+	resolveOverrides := config.RegisterOverrides(flag.CommandLine, os.Getenv)
 	flag.Parse()
 
 	if *showVersion {
@@ -55,12 +56,21 @@ func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	slog.SetDefault(logger)
 
+	overrides, err := resolveOverrides()
+	if err != nil {
+		logger.Error("failed to resolve collector overrides", "err", err)
+		os.Exit(1)
+	}
+
 	cfg, err := config.Load(*configPath)
 	if err != nil {
 		logger.Error("failed to load config", "path", *configPath, "err", err)
 		os.Exit(1)
 	}
-	logger.Info("loaded config", "instances", len(cfg.Instances))
+	logger.Info("loaded config", "instances", len(cfg.Instances),
+		"override_dns", overrides.DNS != nil,
+		"override_dhcp_leases", overrides.DHCPLeases != nil,
+		"override_dhcp_log", overrides.DHCPLog != nil)
 
 	// Self-metrics registry: exporter process + Go runtime.
 	selfRegistry := prometheus.NewRegistry()
@@ -72,7 +82,7 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	probeHandler := exporter.NewProbeHandler(ctx, cfg, logger)
+	probeHandler := exporter.NewProbeHandler(ctx, cfg, overrides, logger)
 
 	mux := http.NewServeMux()
 	mux.Handle(*metricsPath, promhttp.HandlerFor(selfRegistry, promhttp.HandlerOpts{}))

--- a/internal/config/overrides.go
+++ b/internal/config/overrides.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// Overrides is the global override layer over per-instance YAML
+// collector toggles (issue #1). Each field is *bool: nil means "no
+// override — use the YAML setting (or its default)". Set to a
+// non-nil value, the override applies to every instance the exporter
+// knows about.
+//
+// Truthy overrides for the DHCP collectors only enable the collector
+// when the per-instance YAML has the corresponding section populated
+// (e.g. `collectors.dhcp_leases.path` must be set). The override is a
+// kill-switch / opt-in; it doesn't synthesise paths the YAML doesn't
+// supply.
+type Overrides struct {
+	DNS        *bool
+	DHCPLeases *bool
+	DHCPLog    *bool
+}
+
+// Override-flag names. Exported so tests and main can reference them
+// without restating the strings.
+const (
+	flagDNS        = "collector.dns"
+	flagDHCPLeases = "collector.dhcp-leases"
+	flagDHCPLog    = "collector.dhcp-log"
+
+	envDNS        = "PIHOLE_EXPORTER_COLLECTOR_DNS"
+	envDHCPLeases = "PIHOLE_EXPORTER_COLLECTOR_DHCP_LEASES"
+	envDHCPLog    = "PIHOLE_EXPORTER_COLLECTOR_DHCP_LOG"
+)
+
+// RegisterOverrides binds the collector-override flags onto fs.
+// Returns a resolver that the caller invokes after fs.Parse() to
+// produce the final Overrides struct. Splitting registration from
+// resolution lets main keep using the global flag set while remaining
+// testable: tests can pass a fresh FlagSet + custom argv + custom
+// getenv to drive the precedence ladder deterministically.
+//
+// Precedence (highest first): CLI flag → env var → unset (== nil).
+func RegisterOverrides(fs *flag.FlagSet, getenv func(string) string) func() (Overrides, error) {
+	if getenv == nil {
+		getenv = os.Getenv
+	}
+	dns := fs.String(flagDNS, getenv(envDNS),
+		"Global override for the DNS collector toggle. true|false; empty = use per-instance YAML. Env: "+envDNS+".")
+	dhcpLeases := fs.String(flagDHCPLeases, getenv(envDHCPLeases),
+		"Global override for the DHCP-leases collector toggle. true|false; empty = use per-instance YAML. Truthy values still require collectors.dhcp_leases.path to be set per instance. Env: "+envDHCPLeases+".")
+	dhcpLog := fs.String(flagDHCPLog, getenv(envDHCPLog),
+		"Global override for the DHCP-log collector toggle. true|false; empty = use per-instance YAML. Truthy values still require collectors.dhcp_log.path to be set per instance. Env: "+envDHCPLog+".")
+
+	return func() (Overrides, error) {
+		var o Overrides
+		for _, e := range []struct {
+			flagName string
+			raw      *string
+			dst      **bool
+		}{
+			{flagDNS, dns, &o.DNS},
+			{flagDHCPLeases, dhcpLeases, &o.DHCPLeases},
+			{flagDHCPLog, dhcpLog, &o.DHCPLog},
+		} {
+			if *e.raw == "" {
+				continue
+			}
+			b, err := strconv.ParseBool(*e.raw)
+			if err != nil {
+				return Overrides{}, fmt.Errorf("-%s: %q is not a boolean (accepted: true,false,1,0,t,f)", e.flagName, *e.raw)
+			}
+			*e.dst = &b
+		}
+		return o, nil
+	}
+}
+
+// EffectiveDNS returns the effective DNS-collector toggle for inst,
+// taking the global override into account. DNS doesn't require any
+// per-instance YAML config beyond the instance existing, so the
+// override always wins when set.
+func (o Overrides) EffectiveDNS(inst Instance) bool {
+	if o.DNS != nil {
+		return *o.DNS
+	}
+	if inst.Collectors.DNS == nil {
+		return true
+	}
+	return *inst.Collectors.DNS
+}
+
+// EffectiveDHCPLeases returns the effective DHCP-leases toggle for
+// inst. A truthy override only enables the collector when the YAML
+// supplies a path; without the path there's nothing for the collector
+// to read. A falsy override unconditionally disables.
+func (o Overrides) EffectiveDHCPLeases(inst Instance) bool {
+	yamlEnabled := inst.Collectors.DHCPLeases != nil && inst.Collectors.DHCPLeases.Path != ""
+	if o.DHCPLeases == nil {
+		return yamlEnabled
+	}
+	if !*o.DHCPLeases {
+		return false
+	}
+	return yamlEnabled
+}
+
+// EffectiveDHCPLog mirrors EffectiveDHCPLeases. Truthy override + YAML
+// path required; falsy override always wins.
+func (o Overrides) EffectiveDHCPLog(inst Instance) bool {
+	yamlEnabled := inst.Collectors.DHCPLog != nil && inst.Collectors.DHCPLog.Path != ""
+	if o.DHCPLog == nil {
+		return yamlEnabled
+	}
+	if !*o.DHCPLog {
+		return false
+	}
+	return yamlEnabled
+}

--- a/internal/config/overrides_test.go
+++ b/internal/config/overrides_test.go
@@ -1,0 +1,226 @@
+package config
+
+import (
+	"flag"
+	"strings"
+	"testing"
+)
+
+// boolPtr is the test-side counterpart to the *bool fields on
+// Overrides + Collectors. Inline-able but easier to read this way.
+func boolPtr(b bool) *bool { return &b }
+
+func TestRegisterOverrides_PrecedenceCLIBeatsEnv(t *testing.T) {
+	t.Parallel()
+
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	getenv := func(k string) string {
+		switch k {
+		case envDNS:
+			return "false" // env says off
+		default:
+			return ""
+		}
+	}
+	resolve := RegisterOverrides(fs, getenv)
+	if err := fs.Parse([]string{"-collector.dns=true"}); err != nil { // CLI says on
+		t.Fatalf("parse: %v", err)
+	}
+
+	got, err := resolve()
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.DNS == nil || *got.DNS != true {
+		t.Fatalf("CLI should have beaten env; got DNS=%v", got.DNS)
+	}
+}
+
+func TestRegisterOverrides_EnvUsedWhenCLIAbsent(t *testing.T) {
+	t.Parallel()
+
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	getenv := func(k string) string {
+		switch k {
+		case envDHCPLeases:
+			return "1"
+		default:
+			return ""
+		}
+	}
+	resolve := RegisterOverrides(fs, getenv)
+	if err := fs.Parse(nil); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	got, err := resolve()
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.DHCPLeases == nil || *got.DHCPLeases != true {
+		t.Fatalf("env should have set DHCPLeases=true; got %v", got.DHCPLeases)
+	}
+	if got.DNS != nil || got.DHCPLog != nil {
+		t.Fatalf("only DHCPLeases should be set; got %+v", got)
+	}
+}
+
+func TestRegisterOverrides_BothUnsetMeansNil(t *testing.T) {
+	t.Parallel()
+
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	resolve := RegisterOverrides(fs, func(string) string { return "" })
+	if err := fs.Parse(nil); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got, err := resolve()
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.DNS != nil || got.DHCPLeases != nil || got.DHCPLog != nil {
+		t.Fatalf("all overrides should be nil; got %+v", got)
+	}
+}
+
+func TestRegisterOverrides_AcceptsParseBoolForms(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		raw  string
+		want bool
+	}{
+		{"true", true},
+		{"TRUE", true},
+		{"1", true},
+		{"t", true},
+		{"false", false},
+		{"FALSE", false},
+		{"0", false},
+		{"f", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.raw, func(t *testing.T) {
+			fs := flag.NewFlagSet("t", flag.ContinueOnError)
+			resolve := RegisterOverrides(fs, func(string) string { return "" })
+			if err := fs.Parse([]string{"-collector.dns=" + tc.raw}); err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			got, err := resolve()
+			if err != nil {
+				t.Fatalf("resolve: %v", err)
+			}
+			if got.DNS == nil || *got.DNS != tc.want {
+				t.Fatalf("raw %q → DNS=%v, want %v", tc.raw, got.DNS, tc.want)
+			}
+		})
+	}
+}
+
+func TestRegisterOverrides_RejectsGarbage(t *testing.T) {
+	t.Parallel()
+
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	resolve := RegisterOverrides(fs, func(string) string { return "" })
+	if err := fs.Parse([]string{"-collector.dns=maybe"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err := resolve()
+	if err == nil {
+		t.Fatal("expected error for non-boolean value, got nil")
+	}
+	if !strings.Contains(err.Error(), "collector.dns") {
+		t.Fatalf("error should name the offending flag; got %v", err)
+	}
+}
+
+func TestEffectiveDNS_PrecedenceTable(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		override *bool
+		yaml     *bool
+		want     bool
+	}{
+		{"unset → defaults to true", nil, nil, true},
+		{"yaml-only true", nil, boolPtr(true), true},
+		{"yaml-only false", nil, boolPtr(false), false},
+		{"override true wins over yaml false", boolPtr(true), boolPtr(false), true},
+		{"override false wins over yaml true", boolPtr(false), boolPtr(true), false},
+		{"override true with no yaml", boolPtr(true), nil, true},
+		{"override false with no yaml", boolPtr(false), nil, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inst := Instance{Collectors: Collectors{DNS: tc.yaml}}
+			o := Overrides{DNS: tc.override}
+			if got := o.EffectiveDNS(inst); got != tc.want {
+				t.Fatalf("EffectiveDNS = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveDHCPLeases_TruthyOverrideStillNeedsYAMLPath(t *testing.T) {
+	t.Parallel()
+
+	withPath := Instance{Collectors: Collectors{DHCPLeases: &DHCPLeasesConfig{Path: "/etc/pihole/dhcp.leases"}}}
+	withoutPath := Instance{} // no DHCPLeases section at all
+
+	cases := []struct {
+		name     string
+		inst     Instance
+		override *bool
+		want     bool
+	}{
+		// No override → YAML decides.
+		{"unset + path = on", withPath, nil, true},
+		{"unset + no-path = off", withoutPath, nil, false},
+
+		// Truthy override only enables when YAML supplied a path.
+		{"override-true + path = on", withPath, boolPtr(true), true},
+		{"override-true + no-path = STILL off (override can't synthesise path)", withoutPath, boolPtr(true), false},
+
+		// Falsy override always wins.
+		{"override-false + path = off", withPath, boolPtr(false), false},
+		{"override-false + no-path = off", withoutPath, boolPtr(false), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			o := Overrides{DHCPLeases: tc.override}
+			if got := o.EffectiveDHCPLeases(tc.inst); got != tc.want {
+				t.Fatalf("EffectiveDHCPLeases = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveDHCPLog_TruthyOverrideStillNeedsYAMLPath(t *testing.T) {
+	t.Parallel()
+
+	withPath := Instance{Collectors: Collectors{DHCPLog: &DHCPLogConfig{Path: "/var/log/pihole/pihole.log"}}}
+	withoutPath := Instance{}
+
+	cases := []struct {
+		name     string
+		inst     Instance
+		override *bool
+		want     bool
+	}{
+		{"unset + path = on", withPath, nil, true},
+		{"unset + no-path = off", withoutPath, nil, false},
+		{"override-true + path = on", withPath, boolPtr(true), true},
+		{"override-true + no-path = off", withoutPath, boolPtr(true), false},
+		{"override-false + path = off", withPath, boolPtr(false), false},
+		{"override-false + no-path = off", withoutPath, boolPtr(false), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			o := Overrides{DHCPLog: tc.override}
+			if got := o.EffectiveDHCPLog(tc.inst); got != tc.want {
+				t.Fatalf("EffectiveDHCPLog = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/exporter/probe.go
+++ b/internal/exporter/probe.go
@@ -35,12 +35,19 @@ const pingTimeout = 10 * time.Second
 // registry per request. Instances that opt into the dhcp_log collector
 // also get a long-lived tailer goroutine started here; those goroutines
 // stop when ctx is cancelled (typically on SIGINT/SIGTERM in main).
-func NewProbeHandler(ctx context.Context, cfg *config.Config, logger *slog.Logger) http.Handler {
+//
+// `overrides` carries the global CLI/env collector toggles (issue #1).
+// Each effective toggle is computed at handler-build time so the
+// dhcp_log tailer goroutines can be skipped when the operator has
+// killed the collector at the process level — no point starting a
+// goroutine that's never going to register.
+func NewProbeHandler(ctx context.Context, cfg *config.Config, overrides config.Overrides, logger *slog.Logger) http.Handler {
 	h := &probeHandler{
-		cfg:     cfg,
-		logger:  logger,
-		clients: make(map[string]*pihole.Client, len(cfg.Instances)),
-		dhcpLog: make(map[string]*dhcpLogState, len(cfg.Instances)),
+		cfg:       cfg,
+		overrides: overrides,
+		logger:    logger,
+		clients:   make(map[string]*pihole.Client, len(cfg.Instances)),
+		dhcpLog:   make(map[string]*dhcpLogState, len(cfg.Instances)),
 	}
 	for id, inst := range cfg.Instances {
 		h.clients[id] = pihole.NewClient(pihole.Options{
@@ -49,8 +56,8 @@ func NewProbeHandler(ctx context.Context, cfg *config.Config, logger *slog.Logge
 			Timeout:            inst.Timeout,
 			InsecureSkipVerify: inst.InsecureSkipVerify,
 		})
-		if dl := inst.Collectors.DHCPLog; dl != nil && dl.Path != "" {
-			state := newDHCPLogState(id, dl.Path, logger)
+		if overrides.EffectiveDHCPLog(inst) {
+			state := newDHCPLogState(id, inst.Collectors.DHCPLog.Path, logger)
 			h.dhcpLog[id] = state
 			go state.run(ctx)
 		}
@@ -59,11 +66,12 @@ func NewProbeHandler(ctx context.Context, cfg *config.Config, logger *slog.Logge
 }
 
 type probeHandler struct {
-	cfg     *config.Config
-	logger  *slog.Logger
-	mu      sync.Mutex // guards clients + dhcpLog
-	clients map[string]*pihole.Client
-	dhcpLog map[string]*dhcpLogState
+	cfg       *config.Config
+	overrides config.Overrides
+	logger    *slog.Logger
+	mu        sync.Mutex // guards clients + dhcpLog
+	clients   map[string]*pihole.Client
+	dhcpLog   map[string]*dhcpLogState
 }
 
 func (h *probeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -126,15 +134,14 @@ func (h *probeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	up.Set(1)
 
-	// Wire enabled collectors. DNS defaults to on; explicit false in
-	// config disables it (e.g. for an instance scraped only for DHCP
-	// metrics). DHCP collectors are off by default — they need a
-	// readable leases file / log path mounted into the exporter.
-	if inst.Collectors.DNS == nil || *inst.Collectors.DNS {
+	// Wire enabled collectors. The override layer (CLI / env) gets
+	// the final say — see config.Overrides — so this entire chain
+	// reads from the resolved-effective view, not from the raw YAML.
+	if h.overrides.EffectiveDNS(inst) {
 		registry.MustRegister(newDNSCollector(target, client, logger))
 	}
-	if dl := inst.Collectors.DHCPLeases; dl != nil && dl.Path != "" {
-		registry.MustRegister(newDHCPLeasesCollector(target, dl.Path, logger))
+	if h.overrides.EffectiveDHCPLeases(inst) {
+		registry.MustRegister(newDHCPLeasesCollector(target, inst.Collectors.DHCPLeases.Path, logger))
 	}
 	if state := h.dhcpLog[target]; state != nil {
 		registry.MustRegister(newDHCPLogCollector(target, state))


### PR DESCRIPTION
Closes #1.

## Surface

| Flag                     | Env                                       |
| ------------------------ | ----------------------------------------- |
| `-collector.dns`         | `PIHOLE_EXPORTER_COLLECTOR_DNS`           |
| `-collector.dhcp-leases` | `PIHOLE_EXPORTER_COLLECTOR_DHCP_LEASES`   |
| `-collector.dhcp-log`    | `PIHOLE_EXPORTER_COLLECTOR_DHCP_LOG`      |

Each is a string flag. Empty / unset means "no override — use per-instance YAML." `strconv.ParseBool` semantics for the value (`true / TRUE / 1 / t / false / FALSE / 0 / f`); anything else is a startup error.

## Precedence (matches the issue)

**CLI flag → env var → per-instance YAML → built-in default**, highest first.

## Two-rule semantics

- **DNS** — override wins over YAML; YAML default stays "on".
- **DHCP leases / DHCP log** — falsy override unconditionally disables. Truthy override only enables when the per-instance YAML still supplies a path (`collectors.dhcp_leases.path` / `collectors.dhcp_log.path`). The override is a kill-switch / opt-in — it doesn't synthesise paths the YAML didn't supply.

## Implementation

- New `config.Overrides` struct with `*bool` fields (nil = no override).
- New `config.RegisterOverrides(fs, getenv)` binds the flags on the caller's `flag.FlagSet`. Returns a resolver invoked post-`Parse()`. Tests inject a fresh `flag.FlagSet` + a fake `getenv` so the precedence ladder is deterministic.
- New `Overrides.EffectiveDNS(inst) bool`, `EffectiveDHCPLeases(inst) bool`, `EffectiveDHCPLog(inst) bool` collapse the override + per-instance YAML into a single yes/no per collector. The probe handler reads these everywhere it used to read the raw YAML — including the dhcp_log tailer-goroutine startup, so a process-level override actually skips the goroutine instead of starting it then ignoring it.
- `cmd/prometheus_pihole_exporter/main.go` calls `RegisterOverrides` before `flag.Parse`, resolves after `Parse`, logs which overrides are present at startup, and threads the resulting struct into `exporter.NewProbeHandler`.

## Tests

`internal/config/overrides_test.go`:

- `TestRegisterOverrides_PrecedenceCLIBeatsEnv` — env says false, CLI says true → CLI wins.
- `TestRegisterOverrides_EnvUsedWhenCLIAbsent` — env-only path.
- `TestRegisterOverrides_BothUnsetMeansNil` — neither set → all overrides nil.
- `TestRegisterOverrides_AcceptsParseBoolForms` — table over `true / TRUE / 1 / t / false / FALSE / 0 / f`.
- `TestRegisterOverrides_RejectsGarbage` — non-bool value → error names the offending flag.
- `TestEffectiveDNS_PrecedenceTable` — full {override × yaml} cross product.
- `TestEffectiveDHCPLeases_TruthyOverrideStillNeedsYAMLPath` — six cases including "override-true + no-path = STILL off."
- `TestEffectiveDHCPLog_TruthyOverrideStillNeedsYAMLPath` — same shape.

## E2E smoke (against the actual binary)

Built the binary, ran four scenarios against a fake Pi-hole on `127.0.0.1:18080`, counted `pihole_dns_queries_total` lines from `/probe`:

| Scenario | DNS metric line count |
| --- | --- |
| no override | 1 |
| `-collector.dns=false` | 0 |
| `PIHOLE_EXPORTER_COLLECTOR_DNS=false` | 0 |
| `PIHOLE_EXPORTER_COLLECTOR_DNS=false -collector.dns=true` | 1 (CLI wins) |

## Verification

- `go test -race ./… -count=1` — green on all packages.
- `make lint` — clean (golangci-lint v2.3.0 via the project-pinned binary).
- `gofmt -s -l .` empty.
- README updated with the override table + precedence ordering.