### PR TITLE
Fix /api/info/ftl unmarshal for v6 database breakdown shape

### DIFF
--- a/internal/exporter/dns.go
+++ b/internal/exporter/dns.go
@@ -251,7 +251,7 @@ func (c *dnsCollector) emitFTL(ch chan<- prometheus.Metric, ftl pihole.InfoFTL) 
 	ch <- prometheus.MustNewConstMetric(c.dnsmasqAuth, prometheus.CounterValue, float64(d.DNSAuthAnswered))
 	ch <- prometheus.MustNewConstMetric(c.dnsmasqLocal, prometheus.CounterValue, float64(d.DNSLocalAnswered))
 	ch <- prometheus.MustNewConstMetric(c.dnsmasqStale, prometheus.CounterValue, float64(d.DNSStaleAnswered))
-	ch <- prometheus.MustNewConstMetric(c.dnsmasqUnanswered, prometheus.CounterValue, float64(d.DNSUnansweredQueries))
+	ch <- prometheus.MustNewConstMetric(c.dnsmasqUnanswered, prometheus.CounterValue, float64(d.DNSUnanswered))
 }
 
 func upstreamPortLabel(p int) string {

--- a/internal/exporter/dns_test.go
+++ b/internal/exporter/dns_test.go
@@ -111,7 +111,7 @@ func TestDNSCollector_Summary(t *testing.T) {
 			"/api/stats/summary":   string(summaryJSON),
 			"/api/stats/upstreams": string(upstreamsJSON),
 			"/api/dns/blocking":    `{"blocking":"enabled","timer":null}`,
-			"/api/info/ftl":        `{"ftl":{"privacy_level":0,"%mem":1.5,"%cpu":0.7,"clients":{"total":50,"active":12},"dnsmasq":{"dns_cache_inserted":4242,"dns_cache_live_freed":11,"dns_queries_forwarded":600,"dns_auth_answered":12,"dns_local_answered":300,"dns_stale_answered":5,"dns_unanswered_queries":2}}}`,
+			"/api/info/ftl":        `{"ftl":{"privacy_level":0,"%mem":1.5,"%cpu":0.7,"clients":{"total":50,"active":12},"database":{"domains":{"allowed":{"total":3,"enabled":3},"denied":{"total":0,"enabled":0}},"regex":{"allowed":{"total":0,"enabled":0},"denied":{"total":0,"enabled":0}}},"dnsmasq":{"dns_cache_inserted":4242,"dns_cache_live_freed":11,"dns_queries_forwarded":600,"dns_auth_answered":12,"dns_local_answered":300,"dns_stale_answered":5,"dns_unanswered":2}}}`,
 			"/api/info/version":    `{"version":{"core":{"local":{"version":"v6.0.0"}},"ftl":{"local":{"version":"v6.0.1"}},"web":{"local":{"version":"v6.0.0"}}}}`,
 		},
 	}).handler())

--- a/internal/pihole/types.go
+++ b/internal/pihole/types.go
@@ -92,17 +92,25 @@ func orUnknown(s string) string {
 // InfoFTL mirrors GET /api/info/ftl. Only the fields the exporter maps
 // to metrics today are decoded; unknown fields are dropped by
 // json.Unmarshal so adding more is purely additive.
+//
+// Schema notes for Pi-hole v6 (verified against pihole-FTL):
+//
+//   - `database.domains.{allowed,denied}` and
+//     `database.regex.{allowed,denied}` are `{total, enabled}` objects,
+//     not scalars. Earlier exporter releases mis-typed these as int64
+//     and the whole InfoFTL decode failed (taking the dnsmasq counters
+//     down with it).
+//   - The dnsmasq "unanswered" counter is `dns_unanswered`, not
+//     `dns_unanswered_queries`.
 type InfoFTL struct {
 	FTL struct {
 		Database struct {
-			Gravity int64 `json:"gravity"`
-			Groups  int64 `json:"groups"`
-			Lists   int64 `json:"lists"`
-			Clients int64 `json:"clients"`
-			Domains struct {
-				Allowed int64 `json:"allowed"`
-				Denied  int64 `json:"denied"`
-			} `json:"domains"`
+			Gravity int64            `json:"gravity"`
+			Groups  int64            `json:"groups"`
+			Lists   int64            `json:"lists"`
+			Clients int64            `json:"clients"`
+			Domains FTLListBreakdown `json:"domains"`
+			Regex   FTLListBreakdown `json:"regex"`
 		} `json:"database"`
 		PrivacyLevel int `json:"privacy_level"`
 		Clients      struct {
@@ -112,17 +120,25 @@ type InfoFTL struct {
 		MemPercent float64 `json:"%mem"`
 		CPUPercent float64 `json:"%cpu"`
 		DNSMasq    struct {
-			DNSCacheInserted     int64 `json:"dns_cache_inserted"`
-			DNSCacheLiveFreed    int64 `json:"dns_cache_live_freed"`
-			DNSQueriesForwarded  int64 `json:"dns_queries_forwarded"`
-			DNSAuthAnswered      int64 `json:"dns_auth_answered"`
-			DNSLocalAnswered     int64 `json:"dns_local_answered"`
-			DNSStaleAnswered     int64 `json:"dns_stale_answered"`
-			DNSUnansweredQueries int64 `json:"dns_unanswered_queries"`
+			DNSCacheInserted    int64 `json:"dns_cache_inserted"`
+			DNSCacheLiveFreed   int64 `json:"dns_cache_live_freed"`
+			DNSQueriesForwarded int64 `json:"dns_queries_forwarded"`
+			DNSAuthAnswered     int64 `json:"dns_auth_answered"`
+			DNSLocalAnswered    int64 `json:"dns_local_answered"`
+			DNSStaleAnswered    int64 `json:"dns_stale_answered"`
+			DNSUnanswered       int64 `json:"dns_unanswered"`
 		} `json:"dnsmasq"`
 		Type string `json:"type"`
 	} `json:"ftl"`
 	Took float64 `json:"took"`
+}
+
+// FTLListBreakdown is the per-list `{total, enabled}` shape Pi-hole v6
+// uses for `database.{domains,regex}.{allowed,denied}` entries — total
+// rows defined and the subset that's currently active.
+type FTLListBreakdown struct {
+	Total   int64 `json:"total"`
+	Enabled int64 `json:"enabled"`
 }
 
 // DNSBlocking mirrors GET /api/dns/blocking. The string field is one


### PR DESCRIPTION
## Why

Bug spotted while integration-testing v0.1.0 against a real Pi-hole v6 (`mc-01`): every scrape logged

```
dns: ftl info failed err="decode /api/info/ftl: json: cannot unmarshal object into Go struct field .ftl.database.domains.allowed of type int64"
```

and `pihole_collector_up{collector="dns"} = 0`. The dnsmasq counters / FTL CPU + memory percent / clients gauge were all dropped because the JSON decode aborted on a single field.

## Actual v6 schema (verified)

`/api/info/ftl` returns each list-table count as a `{total, enabled}` breakdown, not a scalar:

```jsonc
"database": {
  "domains": { "allowed": {"total": 0, "enabled": 0}, "denied": {"total": 0, "enabled": 0} },
  "regex":   { "allowed": {"total": 0, "enabled": 0}, "denied": {"total": 0, "enabled": 0} }
}
```

Also: the dnsmasq "unanswered" counter is `dns_unanswered`, not `dns_unanswered_queries` (early-v6 docs vs ship-v6 mismatch).

## What changed

- `pihole.InfoFTL` re-typed: `Domains`/`Regex` now `FTLListBreakdown` (`{Total, Enabled int64}`); rename `DNSUnansweredQueries` → `DNSUnanswered`.
- New exported `FTLListBreakdown` type (will be wanted by the metrics surface in v0.2 — separate PR).
- `dns.go` consumes the renamed field (only one site).
- Test fixture rewritten to the real v6 shape so the decoder is exercised against a payload that mirrors what Pi-hole actually emits.

## Out of scope

- New metrics for `database.domains.{allowed,denied}.{total,enabled}` and the `database.regex.*` mirror — additive on top of this fix, deferring to keep the diff focused on the type-shape repair.
- The same `/api/info/ftl` payload turns out to expose **all of the DHCP message counters** (`dhcp_ack`, `dhcp_offer`, `dhcp_request`, …) directly. That makes the dhcp_log tailer collector's whole purpose redundant for DHCP-mode Pi-holes — worth a v0.2 collector refactor: prefer the API counters, keep the log tailer as fallback only when a Pi-hole isn't running DHCP itself but the operator wants to monitor a downstream dnsmasq.

## Verification

- `go test -race ./… -count=1` — green
- `make lint` — 0 issues (golangci-lint v2.3.0)
- `gofmt -s -l .` empty
- Decoded against the actual JSON payload from `mc-01`'s `/api/info/ftl` (saved to `/tmp/ftl.json` during the integration test) — clean unmarshal.