### PR TITLE
Add FTL-API DHCP metrics + release workflow binary artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,8 +85,35 @@ jobs:
           provenance: true
           sbom: true
 
+      # Build raw, statically-linked binaries for direct/baremetal
+      # consumers (e.g. an Ansible role installing a systemd unit on
+      # an ARM SBC that can't run docker). The same -trimpath /
+      # -ldflags shape used by `make build`, applied per-arch.
+      - name: Build standalone binaries (linux/amd64 + linux/arm64)
+        env:
+          VERSION: ${{ github.ref_name }}
+          COMMIT: ${{ github.sha }}
+          DATE: ${{ github.event.head_commit.timestamp }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          for arch in amd64 arm64; do
+            out="dist/prometheus_pihole_exporter-${VERSION}-linux-${arch}"
+            CGO_ENABLED=0 GOOS=linux GOARCH="${arch}" \
+              go build -trimpath \
+                -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" \
+                -o "${out}" ./cmd/prometheus_pihole_exporter
+            ( cd dist && sha256sum "$(basename "${out}")" > "$(basename "${out}").sha256" )
+          done
+          ls -la dist/
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           prerelease: ${{ steps.flavour.outputs.prerelease == 'true' }}
+          files: |
+            dist/prometheus_pihole_exporter-*-linux-amd64
+            dist/prometheus_pihole_exporter-*-linux-amd64.sha256
+            dist/prometheus_pihole_exporter-*-linux-arm64
+            dist/prometheus_pihole_exporter-*-linux-arm64.sha256

--- a/internal/exporter/dns.go
+++ b/internal/exporter/dns.go
@@ -62,6 +62,13 @@ type dnsCollector struct {
 	dnsmasqStale      *prometheus.Desc
 	dnsmasqUnanswered *prometheus.Desc
 
+	// FTL-API-sourced DHCP counters. Coexist with the dhcp_log
+	// collector's `pihole_dhcp_messages_total` (different metric
+	// names so both can run when an operator wants both signals).
+	ftlDHCPMessages        *prometheus.Desc
+	ftlDHCPLeasesAllocated *prometheus.Desc
+	ftlDHCPLeasesPruned    *prometheus.Desc
+
 	// Info gauge (constant 1, labels carry version strings)
 	info *prometheus.Desc
 
@@ -115,6 +122,10 @@ func newDNSCollector(instance string, client *pihole.Client, logger *slog.Logger
 		dnsmasqStale:      d("pihole_dnsmasq_queries_stale_answered_total", "dnsmasq queries answered from stale cache since FTL start."),
 		dnsmasqUnanswered: d("pihole_dnsmasq_queries_unanswered_total", "dnsmasq queries left unanswered since FTL start."),
 
+		ftlDHCPMessages:        d("pihole_ftl_dhcp_messages_total", "DHCP messages observed by Pi-hole's FTL since start, partitioned by message type. Source: /api/info/ftl. Coexists with the log-tailer's pihole_dhcp_messages_total — operators can enable either or both depending on data-source preference.", "type"),
+		ftlDHCPLeasesAllocated: d("pihole_ftl_dhcp_leases_allocated_total", "DHCP leases ever allocated by Pi-hole's FTL since start, partitioned by IP family.", "family"),
+		ftlDHCPLeasesPruned:    d("pihole_ftl_dhcp_leases_pruned_total", "DHCP leases pruned (expired, freed) since FTL start, partitioned by IP family. Currently-active leases approximate to allocated − pruned.", "family"),
+
 		info: d("pihole_info", "Pi-hole component versions reported by the API. Always 1; labels carry the strings.", "core_version", "ftl_version", "web_version"),
 
 		collectorUp: d("pihole_collector_up", "1 if a given collector group's scrape succeeded, 0 otherwise.", "collector"),
@@ -134,6 +145,7 @@ func (c *dnsCollector) Describe(ch chan<- *prometheus.Desc) {
 		c.ftlClientsActive, c.ftlClientsTotal,
 		c.dnsmasqCacheIns, c.dnsmasqCacheFreed, c.dnsmasqForwarded,
 		c.dnsmasqAuth, c.dnsmasqLocal, c.dnsmasqStale, c.dnsmasqUnanswered,
+		c.ftlDHCPMessages, c.ftlDHCPLeasesAllocated, c.ftlDHCPLeasesPruned,
 		c.info, c.collectorUp,
 	}
 	for _, d := range descs {
@@ -252,6 +264,27 @@ func (c *dnsCollector) emitFTL(ch chan<- prometheus.Metric, ftl pihole.InfoFTL) 
 	ch <- prometheus.MustNewConstMetric(c.dnsmasqLocal, prometheus.CounterValue, float64(d.DNSLocalAnswered))
 	ch <- prometheus.MustNewConstMetric(c.dnsmasqStale, prometheus.CounterValue, float64(d.DNSStaleAnswered))
 	ch <- prometheus.MustNewConstMetric(c.dnsmasqUnanswered, prometheus.CounterValue, float64(d.DNSUnanswered))
+
+	// Always-emit zero rows for the v4 DHCP message types so rate()
+	// queries don't need absent() guards. Mirrors the log-tailer's
+	// pattern.
+	dhcpByType := map[string]int64{
+		"DHCPACK":      d.DHCPAck,
+		"DHCPNAK":      d.DHCPNak,
+		"DHCPOFFER":    d.DHCPOffer,
+		"DHCPREQUEST":  d.DHCPRequest,
+		"DHCPDECLINE":  d.DHCPDecline,
+		"DHCPRELEASE":  d.DHCPRelease,
+		"DHCPDISCOVER": d.DHCPDiscover,
+		"DHCPINFORM":   d.DHCPInform,
+	}
+	for t, v := range dhcpByType {
+		ch <- prometheus.MustNewConstMetric(c.ftlDHCPMessages, prometheus.CounterValue, float64(v), t)
+	}
+	ch <- prometheus.MustNewConstMetric(c.ftlDHCPLeasesAllocated, prometheus.CounterValue, float64(d.LeasesAllocated4), "ipv4")
+	ch <- prometheus.MustNewConstMetric(c.ftlDHCPLeasesAllocated, prometheus.CounterValue, float64(d.LeasesAllocated6), "ipv6")
+	ch <- prometheus.MustNewConstMetric(c.ftlDHCPLeasesPruned, prometheus.CounterValue, float64(d.LeasesPruned4), "ipv4")
+	ch <- prometheus.MustNewConstMetric(c.ftlDHCPLeasesPruned, prometheus.CounterValue, float64(d.LeasesPruned6), "ipv6")
 }
 
 func upstreamPortLabel(p int) string {

--- a/internal/exporter/dns_test.go
+++ b/internal/exporter/dns_test.go
@@ -111,7 +111,7 @@ func TestDNSCollector_Summary(t *testing.T) {
 			"/api/stats/summary":   string(summaryJSON),
 			"/api/stats/upstreams": string(upstreamsJSON),
 			"/api/dns/blocking":    `{"blocking":"enabled","timer":null}`,
-			"/api/info/ftl":        `{"ftl":{"privacy_level":0,"%mem":1.5,"%cpu":0.7,"clients":{"total":50,"active":12},"database":{"domains":{"allowed":{"total":3,"enabled":3},"denied":{"total":0,"enabled":0}},"regex":{"allowed":{"total":0,"enabled":0},"denied":{"total":0,"enabled":0}}},"dnsmasq":{"dns_cache_inserted":4242,"dns_cache_live_freed":11,"dns_queries_forwarded":600,"dns_auth_answered":12,"dns_local_answered":300,"dns_stale_answered":5,"dns_unanswered":2}}}`,
+			"/api/info/ftl":        `{"ftl":{"privacy_level":0,"%mem":1.5,"%cpu":0.7,"clients":{"total":50,"active":12},"database":{"domains":{"allowed":{"total":3,"enabled":3},"denied":{"total":0,"enabled":0}},"regex":{"allowed":{"total":0,"enabled":0},"denied":{"total":0,"enabled":0}}},"dnsmasq":{"dns_cache_inserted":4242,"dns_cache_live_freed":11,"dns_queries_forwarded":600,"dns_auth_answered":12,"dns_local_answered":300,"dns_stale_answered":5,"dns_unanswered":2,"dhcp_ack":17,"dhcp_decline":0,"dhcp_discover":4,"dhcp_inform":0,"dhcp_nak":0,"dhcp_offer":4,"dhcp_release":2,"dhcp_request":17,"leases_allocated_4":22,"leases_pruned_4":3,"leases_allocated_6":1,"leases_pruned_6":0}}}`,
 			"/api/info/version":    `{"version":{"core":{"local":{"version":"v6.0.0"}},"ftl":{"local":{"version":"v6.0.1"}},"web":{"local":{"version":"v6.0.0"}}}}`,
 		},
 	}).handler())
@@ -146,6 +146,15 @@ func TestDNSCollector_Summary(t *testing.T) {
 		`pihole_ftl_cpu_percent{instance="primary"} 0.7`,
 		`pihole_dnsmasq_cache_inserted_total{instance="primary"} 4242`,
 		`pihole_dnsmasq_queries_forwarded_total{instance="primary"} 600`,
+		// FTL-API-sourced DHCP counters (no log-tailer needed)
+		`pihole_ftl_dhcp_messages_total{instance="primary",type="DHCPACK"} 17`,
+		`pihole_ftl_dhcp_messages_total{instance="primary",type="DHCPNAK"} 0`,
+		`pihole_ftl_dhcp_messages_total{instance="primary",type="DHCPOFFER"} 4`,
+		`pihole_ftl_dhcp_messages_total{instance="primary",type="DHCPREQUEST"} 17`,
+		`pihole_ftl_dhcp_messages_total{instance="primary",type="DHCPRELEASE"} 2`,
+		`pihole_ftl_dhcp_leases_allocated_total{family="ipv4",instance="primary"} 22`,
+		`pihole_ftl_dhcp_leases_pruned_total{family="ipv4",instance="primary"} 3`,
+		`pihole_ftl_dhcp_leases_allocated_total{family="ipv6",instance="primary"} 1`,
 		`pihole_info{core_version="v6.0.0",ftl_version="v6.0.1",instance="primary",web_version="v6.0.0"} 1`,
 		`pihole_collector_up{collector="dns",instance="primary"} 1`,
 	} {

--- a/internal/pihole/types.go
+++ b/internal/pihole/types.go
@@ -127,6 +127,29 @@ type InfoFTL struct {
 			DNSLocalAnswered    int64 `json:"dns_local_answered"`
 			DNSStaleAnswered    int64 `json:"dns_stale_answered"`
 			DNSUnanswered       int64 `json:"dns_unanswered"`
+
+			// DHCP message counters — Pi-hole v6 surfaces these in
+			// /api/info/ftl, eliminating the need for log-tailing on
+			// pure-DNS-on-DHCP setups. Field names match dnsmasq's
+			// internal counters; the exporter re-keys them as the
+			// canonical DHCPACK / DHCPNAK / etc. message-type strings
+			// when emitting metrics.
+			DHCPAck      int64 `json:"dhcp_ack"`
+			DHCPDecline  int64 `json:"dhcp_decline"`
+			DHCPDiscover int64 `json:"dhcp_discover"`
+			DHCPInform   int64 `json:"dhcp_inform"`
+			DHCPNak      int64 `json:"dhcp_nak"`
+			DHCPOffer    int64 `json:"dhcp_offer"`
+			DHCPRelease  int64 `json:"dhcp_release"`
+			DHCPRequest  int64 `json:"dhcp_request"`
+
+			// Lease lifecycle counters partitioned by IP family. v4 →
+			// IPv4 leases; v6 → IPv6 leases (DHCPv6). Currently-active
+			// lease count ≈ (allocated − pruned).
+			LeasesAllocated4 int64 `json:"leases_allocated_4"`
+			LeasesPruned4    int64 `json:"leases_pruned_4"`
+			LeasesAllocated6 int64 `json:"leases_allocated_6"`
+			LeasesPruned6    int64 `json:"leases_pruned_6"`
 		} `json:"dnsmasq"`
 		Type string `json:"type"`
 	} `json:"ftl"`


### PR DESCRIPTION
Two additions for **v0.1.2**:

## 1. DHCP metrics straight from `/api/info/ftl`

Pi-hole v6 already exposes dnsmasq's DHCP counters in the same FTL info endpoint the DNS collector hits, so the exporter can produce DHCP metrics without a log-tailer or filesystem access to `/etc/pihole/dhcp.leases`. Three new metric families:

| Metric | Labels | Source |
| --- | --- | --- |
| `pihole_ftl_dhcp_messages_total` | `type=DHCPACK\|NAK\|OFFER\|REQUEST\|DECLINE\|RELEASE\|DISCOVER\|INFORM` | `dnsmasq.dhcp_*` |
| `pihole_ftl_dhcp_leases_allocated_total` | `family=ipv4\|ipv6` | `dnsmasq.leases_allocated_{4,6}` |
| `pihole_ftl_dhcp_leases_pruned_total` | `family=ipv4\|ipv6` | `dnsmasq.leases_pruned_{4,6}` |

Always emits zero rows for the eight v4 message types so dashboard `rate()` panels don't need `absent()` guards. Currently-active lease count is approximately `allocated − pruned`.

These metrics live under the `pihole_ftl_dhcp_*` namespace, distinct from the log-tailer's `pihole_dhcp_messages_total`, so an operator can run **either or both** collectors without a label collision.

## 2. Standalone binaries on GitHub releases

The release workflow now builds `-trimpath`/`-ldflags` binaries for `linux/amd64` + `linux/arm64` and attaches them to the GitHub release with `.sha256` sidecars. Lets baremetal consumers (e.g. an Ansible role installing a systemd unit on an ARM SBC that can't run docker) pull a checksummed binary off the release without needing a registry-extraction tool.

Tag aliases for the binaries: `prometheus_pihole_exporter-vX.Y.Z-linux-{amd64,arm64}` and `.sha256`.

## Verification

- `go test -race ./… -count=1` — green; new tests cover the FTL fixture extended with the DHCP fields.
- `make lint` — clean (golangci-lint v2.3.0).
- `gofmt -s -l .` empty.
- `go vet ./…` clean.

## Out of scope (next)

- Active-lease gauge (`pihole_dhcp_leases_active{family}`) currently requires the leases-file collector. v0.2 follow-up: derive a `pihole_dhcp_leases_active_estimate{family} = allocated - pruned` recording rule, or surface it directly here once we sanity-check the semantics on a real cluster.