### PR TITLE
Fix pihole_collector_up Desc collision when multiple collectors run together

### DIFF
--- a/internal/exporter/dhcp_leases.go
+++ b/internal/exporter/dhcp_leases.go
@@ -59,7 +59,17 @@ func newDHCPLeasesCollector(instance, path string, logger *slog.Logger) promethe
 		leasesTotal:   d("pihole_dhcp_leases_total", "All DHCP leases in the leases file (active + expired), partitioned by IP family.", familyLabel),
 		leaseInfo:     d("pihole_dhcp_lease_info", "Always 1; labels identify a specific DHCP lease.", macLabel, ipLabel, hostnameLabel, familyLabel),
 		leaseExpires:  d("pihole_dhcp_lease_expires_timestamp_seconds", "Unix timestamp at which a given DHCP lease expires.", macLabel, ipLabel, hostnameLabel, familyLabel),
-		collectorUp:   d("pihole_collector_up", "1 if a given collector group's scrape succeeded, 0 otherwise.", "collector"),
+		// `collector` is a CONST label so each collector's Desc is a
+		// distinct registry identity (otherwise N collectors all
+		// declaring pihole_collector_up{instance=…} would crash
+		// MustRegister with "already exists with the same fqName +
+		// const labels"). See dns.go for the same pattern.
+		collectorUp: prometheus.NewDesc(
+			"pihole_collector_up",
+			"1 if a given collector group's scrape succeeded, 0 otherwise.",
+			nil,
+			prometheus.Labels{"instance": instance, "collector": "dhcp_leases"},
+		),
 	}
 }
 
@@ -73,7 +83,7 @@ func (c *dhcpLeasesCollector) Collect(ch chan<- prometheus.Metric) {
 	leases, err := readLeases(c.path)
 	if err != nil {
 		c.logger.Warn("dhcp_leases: read failed", "instance", c.instance, "path", c.path, "err", err)
-		ch <- prometheus.MustNewConstMetric(c.collectorUp, prometheus.GaugeValue, 0, "dhcp_leases")
+		ch <- prometheus.MustNewConstMetric(c.collectorUp, prometheus.GaugeValue, 0)
 		return
 	}
 
@@ -104,7 +114,7 @@ func (c *dhcpLeasesCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(c.leasesTotal, prometheus.GaugeValue, float64(entry[2]), fam)
 	}
 
-	ch <- prometheus.MustNewConstMetric(c.collectorUp, prometheus.GaugeValue, 1, "dhcp_leases")
+	ch <- prometheus.MustNewConstMetric(c.collectorUp, prometheus.GaugeValue, 1)
 }
 
 // lease is one parsed entry from the leases file.

--- a/internal/exporter/dhcp_log.go
+++ b/internal/exporter/dhcp_log.go
@@ -184,7 +184,15 @@ func newDHCPLogCollector(instance string, state *dhcpLogState) prometheus.Collec
 		descMsgTotal:    d("pihole_dhcp_messages_total", "Number of DHCP messages observed in the dnsmasq log since the exporter started, partitioned by type.", "type"),
 		descParseErrors: d("pihole_dhcp_log_parse_errors_total", "Errors encountered while parsing the dnsmasq log."),
 		descLastEvent:   d("pihole_dhcp_log_last_event_timestamp_seconds", "Unix timestamp of the most recently observed DHCP event (0 if none yet)."),
-		descCollectorUp: d("pihole_collector_up", "1 if a given collector group's scrape succeeded, 0 otherwise.", "collector"),
+		// `collector` is a CONST label so each collector's Desc is a
+		// distinct registry identity. See dns.go / dhcp_leases.go for
+		// the same pattern.
+		descCollectorUp: prometheus.NewDesc(
+			"pihole_collector_up",
+			"1 if a given collector group's scrape succeeded, 0 otherwise.",
+			nil,
+			prometheus.Labels{"instance": instance, "collector": "dhcp_log"},
+		),
 	}
 }
 
@@ -220,5 +228,5 @@ func (c *dhcpLogCollector) Collect(ch chan<- prometheus.Metric) {
 	if healthy {
 		upVal = 1
 	}
-	ch <- prometheus.MustNewConstMetric(c.descCollectorUp, prometheus.GaugeValue, upVal, "dhcp_log")
+	ch <- prometheus.MustNewConstMetric(c.descCollectorUp, prometheus.GaugeValue, upVal)
 }

--- a/internal/exporter/dns.go
+++ b/internal/exporter/dns.go
@@ -128,7 +128,19 @@ func newDNSCollector(instance string, client *pihole.Client, logger *slog.Logger
 
 		info: d("pihole_info", "Pi-hole component versions reported by the API. Always 1; labels carry the strings.", "core_version", "ftl_version", "web_version"),
 
-		collectorUp: d("pihole_collector_up", "1 if a given collector group's scrape succeeded, 0 otherwise.", "collector"),
+		// Per-collector health gauge — `collector` is a CONST label
+		// here (not a variable label) so each collector's instance of
+		// this Desc has a different identity in Prometheus's registry.
+		// Otherwise three collectors declaring `pihole_collector_up`
+		// with identical const labels would all collide and crash
+		// MustRegister (Pi-hole v6 #issue surfaced when DNS + leases +
+		// log all run on the same systemd-mode host).
+		collectorUp: prometheus.NewDesc(
+			"pihole_collector_up",
+			"1 if a given collector group's scrape succeeded, 0 otherwise.",
+			nil,
+			prometheus.Labels{"instance": instance, "collector": "dns"},
+		),
 	}
 }
 
@@ -209,7 +221,7 @@ func (c *dnsCollector) Collect(ch chan<- prometheus.Metric) {
 	if allOK {
 		upVal = 1
 	}
-	ch <- prometheus.MustNewConstMetric(c.collectorUp, prometheus.GaugeValue, upVal, "dns")
+	ch <- prometheus.MustNewConstMetric(c.collectorUp, prometheus.GaugeValue, upVal)
 }
 
 func (c *dnsCollector) emitSummary(ch chan<- prometheus.Metric, s pihole.StatsSummary) {

--- a/internal/exporter/multicollector_test.go
+++ b/internal/exporter/multicollector_test.go
@@ -1,0 +1,35 @@
+package exporter
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/reloaded/prometheus_pihole_exporter/internal/pihole"
+)
+
+// TestAllCollectorsRegisterTogether is a regression test for the
+// "descriptor pihole_collector_up already exists" panic that fired in
+// systemd mode the first time DNS + DHCP leases + DHCP log collectors
+// all ran on the same probe handler. The fix moved `collector` from a
+// variable label to a const label per collector, giving each its own
+// Desc identity in Prometheus's registry.
+func TestAllCollectorsRegisterTogether(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	registry := prometheus.NewRegistry()
+
+	dns := newDNSCollector("primary", pihole.NewClient(pihole.Options{BaseURL: "http://127.0.0.1:1", Password: "x"}), logger)
+	leases := newDHCPLeasesCollector("primary", "/dev/null", logger)
+	logState := newDHCPLogState("primary", "/dev/null", logger)
+	dlog := newDHCPLogCollector("primary", logState)
+
+	for i, c := range []prometheus.Collector{dns, leases, dlog} {
+		if err := registry.Register(c); err != nil {
+			t.Fatalf("collector %d failed to register on shared registry: %v", i, err)
+		}
+	}
+}


### PR DESCRIPTION
## Bug

DNS, DHCP-leases, and DHCP-log collectors each declared `pihole_collector_up` with identical fqName + const labels but a variable `collector` label. Prometheus's registry treats Desc identity as `(fqName, constLabels)` — collectors that match on both panic on `MustRegister`.

The bug stayed latent through v0.1.0 → v0.1.2 because earlier deploys (k8s mode) only enabled DNS, leaving the DHCP collectors off. The first systemd-mode-on-Pi-hole-host deploy enables all three on the same probe handler — request 1 panics:

```
http: panic serving …: descriptor Desc{fqName: "pihole_collector_up", …,
constLabels: {instance="primary"}, variableLabels: {collector}} already
exists with the same fully-qualified name and const label values
```

Connection accepted, panic during ServeHTTP, client sees `EOF` / `Empty reply from server`. Discovered while integration-testing the new systemd runtime against `mc-01`.

## Fix

Move `collector` from a variable label to a CONST label per collector, with the value baked in at construction. Each collector's Desc identity becomes unique:

| Collector | Desc const labels |
| --- | --- |
| DNS | `{instance, collector="dns"}` |
| DHCP leases | `{instance, collector="dhcp_leases"}` |
| DHCP log | `{instance, collector="dhcp_log"}` |

Three distinct Desc identities → registers cleanly alongside the others. Prometheus output is **byte-identical** to operators — they still see `pihole_collector_up{instance="primary",collector="dns"} 1` etc.

## Regression test

`TestAllCollectorsRegisterTogether` constructs all three collectors against a shared `prometheus.NewRegistry()` and `Register`s each. Would have caught this in CI.

## Verification

- `go test -race ./… -count=1` — green; new regression test passes
- `make lint` clean (golangci-lint v2.3.0)
- `gofmt -s -l .` empty

Cuts as `v0.1.3`.