### PR TITLE
Expose Pi-hole windowed totals as monotonic Prometheus counters

### DIFF
--- a/internal/exporter/dns.go
+++ b/internal/exporter/dns.go
@@ -20,6 +20,13 @@ type dnsCollector struct {
 	client   *pihole.Client
 	logger   *slog.Logger
 
+	// counters holds the long-lived accumulators that turn Pi-hole's
+	// 24-hour rolling totals into monotonic Prometheus counters.
+	// Owned by probeHandler so the state persists across /probe
+	// requests; the collector borrows a pointer for the duration of
+	// one Collect() call. See windowed_counter.go.
+	counters *dnsCounters
+
 	// Top-line DNS counters / gauges
 	queriesTotal      *prometheus.Desc
 	queriesBlocked    *prometheus.Desc
@@ -76,7 +83,7 @@ type dnsCollector struct {
 	collectorUp *prometheus.Desc
 }
 
-func newDNSCollector(instance string, client *pihole.Client, logger *slog.Logger) prometheus.Collector {
+func newDNSCollector(instance string, client *pihole.Client, counters *dnsCounters, logger *slog.Logger) prometheus.Collector {
 	labels := prometheus.Labels{"instance": instance}
 	d := func(name, help string, varLabels ...string) *prometheus.Desc {
 		return prometheus.NewDesc(name, help, varLabels, labels)
@@ -84,15 +91,22 @@ func newDNSCollector(instance string, client *pihole.Client, logger *slog.Logger
 	return &dnsCollector{
 		instance: instance,
 		client:   client,
+		counters: counters,
 		logger:   logger,
 
-		queriesTotal:      d("pihole_dns_queries_total", "Pi-hole DNS queries handled today (resets at midnight, treat as a Counter)."),
-		queriesBlocked:    d("pihole_dns_queries_blocked_total", "Pi-hole DNS queries blocked today (resets at midnight)."),
-		queriesForwarded:  d("pihole_dns_queries_forwarded_total", "Pi-hole DNS queries forwarded to upstream resolvers today (resets at midnight)."),
-		queriesCached:     d("pihole_dns_queries_cached_total", "Pi-hole DNS queries answered from local cache today (resets at midnight)."),
-		queriesByType:     d("pihole_dns_queries_by_type_total", "Pi-hole DNS queries today, partitioned by record type (resets at midnight).", "type"),
-		queriesByStatus:   d("pihole_dns_queries_by_status_total", "Pi-hole DNS queries today, partitioned by FTL status (resets at midnight).", "status"),
-		queriesByReply:    d("pihole_dns_queries_by_reply_total", "Pi-hole DNS queries today, partitioned by reply category (resets at midnight).", "reply"),
+		// _total help strings reflect the *exporter-process-lifetime*
+		// semantics produced by the windowed→monotonic accumulators
+		// (see windowed_counter.go). Pi-hole's API itself reports
+		// 24-hour rolling totals; raw forwarding broke rate(), so the
+		// exporter now accumulates only the positive deltas across
+		// scrapes and exposes a true Prometheus counter.
+		queriesTotal:      d("pihole_dns_queries_total", "Pi-hole DNS queries handled, accumulated since exporter start."),
+		queriesBlocked:    d("pihole_dns_queries_blocked_total", "Pi-hole DNS queries blocked, accumulated since exporter start."),
+		queriesForwarded:  d("pihole_dns_queries_forwarded_total", "Pi-hole DNS queries forwarded to upstream resolvers, accumulated since exporter start."),
+		queriesCached:     d("pihole_dns_queries_cached_total", "Pi-hole DNS queries answered from local cache, accumulated since exporter start."),
+		queriesByType:     d("pihole_dns_queries_by_type_total", "Pi-hole DNS queries by record type, accumulated since exporter start.", "type"),
+		queriesByStatus:   d("pihole_dns_queries_by_status_total", "Pi-hole DNS queries by FTL status, accumulated since exporter start.", "status"),
+		queriesByReply:    d("pihole_dns_queries_by_reply_total", "Pi-hole DNS queries by reply category, accumulated since exporter start.", "reply"),
 		queriesUnique:     d("pihole_dns_queries_unique_domains", "Distinct domains queried today (gauge)."),
 		queriesFrequency:  d("pihole_dns_queries_per_second", "Pi-hole's reported short-window query rate (gauge)."),
 		queriesPctBlocked: d("pihole_dns_queries_blocked_ratio", "Fraction of today's queries that were blocked (0–1)."),
@@ -103,7 +117,7 @@ func newDNSCollector(instance string, client *pihole.Client, logger *slog.Logger
 		gravityDomains:      d("pihole_gravity_domains", "Number of domains in the gravity (blocklist) table."),
 		gravityLastUpdateTs: d("pihole_gravity_last_update_timestamp_seconds", "Unix timestamp of the last gravity database refresh."),
 
-		upstreamQueries:      d("pihole_dns_upstream_queries_total", "Today's queries forwarded to a given upstream destination (resets at midnight).", "upstream", "ip", "port"),
+		upstreamQueries:      d("pihole_dns_upstream_queries_total", "Queries forwarded to a given upstream destination, accumulated since exporter start.", "upstream", "ip", "port"),
 		upstreamResponseSecs: d("pihole_dns_upstream_response_seconds", "Mean response time from a given upstream destination (Pi-hole's reported value).", "upstream", "ip", "port"),
 		upstreamVarianceSecs: d("pihole_dns_upstream_response_variance_seconds", "Variance of response time from a given upstream destination (Pi-hole's reported value).", "upstream", "ip", "port"),
 
@@ -226,22 +240,28 @@ func (c *dnsCollector) Collect(ch chan<- prometheus.Metric) {
 
 func (c *dnsCollector) emitSummary(ch chan<- prometheus.Metric, s pihole.StatsSummary) {
 	q := s.Queries
-	ch <- prometheus.MustNewConstMetric(c.queriesTotal, prometheus.CounterValue, float64(q.Total))
-	ch <- prometheus.MustNewConstMetric(c.queriesBlocked, prometheus.CounterValue, float64(q.Blocked))
-	ch <- prometheus.MustNewConstMetric(c.queriesForwarded, prometheus.CounterValue, float64(q.Forwarded))
-	ch <- prometheus.MustNewConstMetric(c.queriesCached, prometheus.CounterValue, float64(q.Cached))
+	// All four scalar _total emissions wrap the upstream value with
+	// a windowed→monotonic accumulator (see windowed_counter.go).
+	// Pi-hole's API reports 24-hour rolling totals that drop at FTL
+	// flush boundaries; passing the raw value to Prometheus broke
+	// rate() with periodic spike artefacts.
+	ch <- prometheus.MustNewConstMetric(c.queriesTotal, prometheus.CounterValue, float64(c.counters.queriesTotal.observe(q.Total)))
+	ch <- prometheus.MustNewConstMetric(c.queriesBlocked, prometheus.CounterValue, float64(c.counters.queriesBlocked.observe(q.Blocked)))
+	ch <- prometheus.MustNewConstMetric(c.queriesForwarded, prometheus.CounterValue, float64(c.counters.queriesForwarded.observe(q.Forwarded)))
+	ch <- prometheus.MustNewConstMetric(c.queriesCached, prometheus.CounterValue, float64(c.counters.queriesCached.observe(q.Cached)))
 	ch <- prometheus.MustNewConstMetric(c.queriesUnique, prometheus.GaugeValue, float64(q.UniqueDomains))
 	ch <- prometheus.MustNewConstMetric(c.queriesFrequency, prometheus.GaugeValue, q.Frequency)
 	ch <- prometheus.MustNewConstMetric(c.queriesPctBlocked, prometheus.GaugeValue, q.PercentBlocked/100)
 
 	for k, v := range q.Types {
-		ch <- prometheus.MustNewConstMetric(c.queriesByType, prometheus.CounterValue, float64(v), strings.ToUpper(k))
+		t := strings.ToUpper(k)
+		ch <- prometheus.MustNewConstMetric(c.queriesByType, prometheus.CounterValue, float64(c.counters.queriesByType.observe(v, t)), t)
 	}
 	for k, v := range q.Status {
-		ch <- prometheus.MustNewConstMetric(c.queriesByStatus, prometheus.CounterValue, float64(v), k)
+		ch <- prometheus.MustNewConstMetric(c.queriesByStatus, prometheus.CounterValue, float64(c.counters.queriesByStatus.observe(v, k)), k)
 	}
 	for k, v := range q.Replies {
-		ch <- prometheus.MustNewConstMetric(c.queriesByReply, prometheus.CounterValue, float64(v), k)
+		ch <- prometheus.MustNewConstMetric(c.queriesByReply, prometheus.CounterValue, float64(c.counters.queriesByReply.observe(v, k)), k)
 	}
 
 	ch <- prometheus.MustNewConstMetric(c.clientsActive, prometheus.GaugeValue, float64(s.Clients.Active))
@@ -254,7 +274,10 @@ func (c *dnsCollector) emitSummary(ch chan<- prometheus.Metric, s pihole.StatsSu
 func (c *dnsCollector) emitUpstreams(ch chan<- prometheus.Metric, u pihole.StatsUpstreams) {
 	for _, up := range u.Upstreams {
 		port := upstreamPortLabel(up.Port)
-		ch <- prometheus.MustNewConstMetric(c.upstreamQueries, prometheus.CounterValue, float64(up.Count), up.Name, up.IP, port)
+		// upstreamQueries is windowed (per-upstream 24-hour total) →
+		// accumulate; the *_seconds gauges are instantaneous and pass
+		// through.
+		ch <- prometheus.MustNewConstMetric(c.upstreamQueries, prometheus.CounterValue, float64(c.counters.upstreamQueries.observe(up.Count, up.Name, up.IP, port)), up.Name, up.IP, port)
 		ch <- prometheus.MustNewConstMetric(c.upstreamResponseSecs, prometheus.GaugeValue, up.Statistics.Response, up.Name, up.IP, port)
 		ch <- prometheus.MustNewConstMetric(c.upstreamVarianceSecs, prometheus.GaugeValue, up.Statistics.Variance, up.Name, up.IP, port)
 	}

--- a/internal/exporter/dns_counters.go
+++ b/internal/exporter/dns_counters.go
@@ -1,0 +1,35 @@
+package exporter
+
+// dnsCounters bundles the long-lived windowed→monotonic accumulators
+// for one Pi-hole instance's DNS collector. Lives on probeHandler so
+// it survives across /probe requests — the collector itself is
+// rebuilt per request to keep registry state isolated, but the
+// accumulator state has to persist or every scrape would re-prime
+// the baseline at the upstream's current 24-hour total.
+//
+// Only metrics whose upstream value is windowed are wrapped here.
+// FTL-lifetime counters (the dnsmasq_* family, the FTL DHCP family,
+// FTL lease totals) come from FTL's *since-FTL-start* numbers and
+// are already monotonic with respect to FTL's process; Prometheus's
+// built-in counter-reset handling deals with FTL restarts.
+type dnsCounters struct {
+	queriesTotal     windowedCounter
+	queriesBlocked   windowedCounter
+	queriesForwarded windowedCounter
+	queriesCached    windowedCounter
+
+	queriesByType   *windowedCounters
+	queriesByStatus *windowedCounters
+	queriesByReply  *windowedCounters
+
+	upstreamQueries *windowedCounters
+}
+
+func newDNSCounters() *dnsCounters {
+	return &dnsCounters{
+		queriesByType:   newWindowedCounters(),
+		queriesByStatus: newWindowedCounters(),
+		queriesByReply:  newWindowedCounters(),
+		upstreamQueries: newWindowedCounters(),
+	}
+}

--- a/internal/exporter/dns_test.go
+++ b/internal/exporter/dns_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -18,9 +19,14 @@ import (
 
 // fakePihole is a minimal in-memory Pi-hole that can be steered per-test
 // via responses keyed on path. It handles the v6 auth handshake out of
-// the box.
+// the box. The mutex makes mid-test response swaps safe — the
+// windowed-counter tests need to drive the same collector through
+// multiple Gather() rounds with different upstream values to verify
+// delta accumulation.
 type fakePihole struct {
-	t         *testing.T
+	t *testing.T
+
+	mu        sync.RWMutex
 	responses map[string]string // path → JSON body
 	status    map[string]int    // optional override (defaults to 200)
 }
@@ -33,17 +39,28 @@ func (f *fakePihole) handler() http.Handler {
 			_, _ = w.Write([]byte(`{"session":{"valid":true,"sid":"S","validity":1800}}`))
 			return
 		}
+		f.mu.RLock()
 		body, ok := f.responses[r.URL.Path]
+		code := f.status[r.URL.Path]
+		f.mu.RUnlock()
 		if !ok {
 			http.NotFound(w, r)
 			return
 		}
-		if code := f.status[r.URL.Path]; code != 0 {
+		if code != 0 {
 			w.WriteHeader(code)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(body))
 	})
+}
+
+// setResponse swaps the fake server's body for a given path. Used to
+// replay multi-scrape traces in the windowed-counter test.
+func (f *fakePihole) setResponse(path, body string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.responses[path] = body
 }
 
 // gatherText returns the rendered text-format metrics for the given
@@ -119,15 +136,27 @@ func TestDNSCollector_Summary(t *testing.T) {
 
 	c := newDNSCollector("primary",
 		pihole.NewClient(pihole.Options{BaseURL: srv.URL, Password: "x"}),
+		newDNSCounters(),
 		slog.New(slog.NewTextHandler(io.Discard, nil)))
 
+	// First Gather primes the windowed→monotonic accumulators — every
+	// _total wrapped by the accumulator reads back as 0. The gauges
+	// and the FTL-lifetime _total counters (dnsmasq_*, ftl_dhcp_*)
+	// pass through unchanged on the first scrape.
 	got := gatherText(t, c)
 
 	for _, want := range []string{
-		`pihole_dns_queries_total{instance="primary"} 1000`,
-		`pihole_dns_queries_blocked_total{instance="primary"} 100`,
-		`pihole_dns_queries_forwarded_total{instance="primary"} 600`,
-		`pihole_dns_queries_cached_total{instance="primary"} 300`,
+		// Windowed → primed to 0 on first scrape.
+		`pihole_dns_queries_total{instance="primary"} 0`,
+		`pihole_dns_queries_blocked_total{instance="primary"} 0`,
+		`pihole_dns_queries_forwarded_total{instance="primary"} 0`,
+		`pihole_dns_queries_cached_total{instance="primary"} 0`,
+		`pihole_dns_queries_by_type_total{instance="primary",type="A"} 0`,
+		`pihole_dns_queries_by_type_total{instance="primary",type="AAAA"} 0`,
+		`pihole_dns_queries_by_status_total{instance="primary",status="GRAVITY"} 0`,
+		`pihole_dns_queries_by_reply_total{instance="primary",reply="NXDOMAIN"} 0`,
+		`pihole_dns_upstream_queries_total{instance="primary",ip="9.9.9.9",port="53",upstream="9.9.9.9#53"} 0`,
+		// Gauges and FTL-lifetime counters pass through.
 		`pihole_dns_queries_blocked_ratio{instance="primary"} 0.1`,
 		`pihole_dns_queries_unique_domains{instance="primary"} 250`,
 		`pihole_dns_queries_per_second{instance="primary"} 3.5`,
@@ -136,11 +165,6 @@ func TestDNSCollector_Summary(t *testing.T) {
 		`pihole_gravity_domains{instance="primary"} 250000`,
 		`pihole_gravity_last_update_timestamp_seconds{instance="primary"} 1.7e+09`,
 		`pihole_blocking_enabled{instance="primary"} 1`,
-		`pihole_dns_queries_by_type_total{instance="primary",type="A"} 700`,
-		`pihole_dns_queries_by_type_total{instance="primary",type="AAAA"} 200`,
-		`pihole_dns_queries_by_status_total{instance="primary",status="GRAVITY"} 100`,
-		`pihole_dns_queries_by_reply_total{instance="primary",reply="NXDOMAIN"} 5`,
-		`pihole_dns_upstream_queries_total{instance="primary",ip="9.9.9.9",port="53",upstream="9.9.9.9#53"} 600`,
 		`pihole_dns_upstream_response_seconds{instance="primary",ip="9.9.9.9",port="53",upstream="9.9.9.9#53"} 0.05`,
 		`pihole_ftl_memory_percent{instance="primary"} 1.5`,
 		`pihole_ftl_cpu_percent{instance="primary"} 0.7`,
@@ -181,6 +205,7 @@ func TestDNSCollector_BlockingDisabled(t *testing.T) {
 
 	c := newDNSCollector("primary",
 		pihole.NewClient(pihole.Options{BaseURL: srv.URL, Password: "x"}),
+		newDNSCounters(),
 		slog.New(slog.NewTextHandler(io.Discard, nil)))
 
 	got := gatherText(t, c)
@@ -209,15 +234,152 @@ func TestDNSCollector_PartialFailure(t *testing.T) {
 
 	c := newDNSCollector("primary",
 		pihole.NewClient(pihole.Options{BaseURL: srv.URL, Password: "x"}),
+		newDNSCounters(),
 		slog.New(slog.NewTextHandler(io.Discard, nil)))
 
 	got := gatherText(t, c)
 	// Summary succeeded, upstreams failed → collector_up should be 0,
-	// but the summary metrics should still have been emitted.
+	// but the summary metrics should still have been emitted (here
+	// reading 0 because this is the first scrape and the accumulator
+	// is priming the baseline).
 	if !strings.Contains(got, `pihole_collector_up{collector="dns",instance="primary"} 0`) {
 		t.Fatalf("expected collector_up=0 when an endpoint fails, got:\n%s", got)
 	}
-	if !strings.Contains(got, `pihole_dns_queries_total{instance="primary"} 1`) {
-		t.Fatalf("expected partial summary metrics, got:\n%s", got)
+	if !strings.Contains(got, `pihole_dns_queries_total{instance="primary"} 0`) {
+		t.Fatalf("expected partial summary metrics (primed to 0 on first scrape), got:\n%s", got)
+	}
+}
+
+// TestDNSCollector_WindowedCountersAcrossScrapes drives the same
+// collector through four Gather() rounds against a fakePihole that
+// replays a realistic Pi-hole trace: prime, growth, window flush,
+// post-flush growth. Verifies that the windowed→monotonic wiring in
+// emitSummary / emitUpstreams produces values rate() can consume
+// without spike artefacts.
+func TestDNSCollector_WindowedCountersAcrossScrapes(t *testing.T) {
+	t.Parallel()
+
+	mkSummary := func(total, blocked, forwarded, cached int64, byType map[string]int64) string {
+		s := pihole.StatsSummary{}
+		s.Queries.Total = total
+		s.Queries.Blocked = blocked
+		s.Queries.Forwarded = forwarded
+		s.Queries.Cached = cached
+		s.Queries.Types = byType
+		b, _ := json.Marshal(s)
+		return string(b)
+	}
+	mkUpstreams := func(count int64) string {
+		u := pihole.StatsUpstreams{}
+		u.Upstreams = append(u.Upstreams, struct {
+			IP         string `json:"ip"`
+			Name       string `json:"name"`
+			Port       int    `json:"port"`
+			Count      int64  `json:"count"`
+			Statistics struct {
+				Response float64 `json:"response"`
+				Variance float64 `json:"variance"`
+			} `json:"statistics"`
+		}{IP: "9.9.9.9", Name: "9.9.9.9#53", Port: 53, Count: count})
+		b, _ := json.Marshal(u)
+		return string(b)
+	}
+
+	fp := &fakePihole{
+		t: t,
+		responses: map[string]string{
+			"/api/stats/summary":   mkSummary(1000, 100, 600, 300, map[string]int64{"A": 700}),
+			"/api/stats/upstreams": mkUpstreams(600),
+			"/api/dns/blocking":    `{"blocking":"enabled","timer":null}`,
+			"/api/info/ftl":        `{"ftl":{}}`,
+			"/api/info/version":    `{"version":{}}`,
+		},
+	}
+	srv := httptest.NewServer(fp.handler())
+	defer srv.Close()
+
+	c := newDNSCollector("primary",
+		pihole.NewClient(pihole.Options{BaseURL: srv.URL, Password: "x"}),
+		newDNSCounters(),
+		slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	register := prometheus.NewRegistry()
+	register.MustRegister(c)
+	gather := func() string {
+		t.Helper()
+		mfs, err := register.Gather()
+		if err != nil {
+			t.Fatalf("Gather: %v", err)
+		}
+		var buf bytes.Buffer
+		enc := expfmt.NewEncoder(&buf, expfmt.NewFormat(expfmt.TypeTextPlain))
+		for _, mf := range mfs {
+			if err := enc.Encode(mf); err != nil {
+				t.Fatalf("encode: %v", err)
+			}
+		}
+		return buf.String()
+	}
+
+	// Round 1 — prime. Every windowed _total reads 0.
+	got := gather()
+	for _, want := range []string{
+		`pihole_dns_queries_total{instance="primary"} 0`,
+		`pihole_dns_queries_blocked_total{instance="primary"} 0`,
+		`pihole_dns_queries_by_type_total{instance="primary",type="A"} 0`,
+		`pihole_dns_upstream_queries_total{instance="primary",ip="9.9.9.9",port="53",upstream="9.9.9.9#53"} 0`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("round 1 (prime): missing %q in:\n%s", want, got)
+		}
+	}
+
+	// Round 2 — growth. q.Total: 1000 → 1500 → expected lifetime 500;
+	// upstream.Count: 600 → 850 → expected lifetime 250.
+	fp.setResponse("/api/stats/summary", mkSummary(1500, 150, 850, 500, map[string]int64{"A": 1050}))
+	fp.setResponse("/api/stats/upstreams", mkUpstreams(850))
+	got = gather()
+	for _, want := range []string{
+		`pihole_dns_queries_total{instance="primary"} 500`,
+		`pihole_dns_queries_blocked_total{instance="primary"} 50`,
+		`pihole_dns_queries_by_type_total{instance="primary",type="A"} 350`,
+		`pihole_dns_upstream_queries_total{instance="primary",ip="9.9.9.9",port="53",upstream="9.9.9.9#53"} 250`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("round 2 (growth): missing %q in:\n%s", want, got)
+		}
+	}
+
+	// Round 3 — window flush. Upstream values drop; lifetime must
+	// not roll backwards. This is the spike-producing scenario the
+	// accumulator exists to defuse.
+	fp.setResponse("/api/stats/summary", mkSummary(1380, 140, 780, 460, map[string]int64{"A": 950}))
+	fp.setResponse("/api/stats/upstreams", mkUpstreams(780))
+	got = gather()
+	for _, want := range []string{
+		`pihole_dns_queries_total{instance="primary"} 500`,
+		`pihole_dns_queries_blocked_total{instance="primary"} 50`,
+		`pihole_dns_queries_by_type_total{instance="primary",type="A"} 350`,
+		`pihole_dns_upstream_queries_total{instance="primary",ip="9.9.9.9",port="53",upstream="9.9.9.9#53"} 250`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("round 3 (flush): missing %q in:\n%s", want, got)
+		}
+	}
+
+	// Round 4 — post-flush growth. New floor is 1380; rising to
+	// 1480 adds 100 to lifetime → 600 total. Same shape per series.
+	fp.setResponse("/api/stats/summary", mkSummary(1480, 145, 850, 485, map[string]int64{"A": 1010}))
+	fp.setResponse("/api/stats/upstreams", mkUpstreams(850))
+	got = gather()
+	for _, want := range []string{
+		`pihole_dns_queries_total{instance="primary"} 600`,
+		`pihole_dns_queries_blocked_total{instance="primary"} 55`,
+		`pihole_dns_queries_by_type_total{instance="primary",type="A"} 410`,
+		`pihole_dns_upstream_queries_total{instance="primary",ip="9.9.9.9",port="53",upstream="9.9.9.9#53"} 320`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("round 4 (post-flush growth): missing %q in:\n%s", want, got)
+		}
 	}
 }

--- a/internal/exporter/multicollector_test.go
+++ b/internal/exporter/multicollector_test.go
@@ -22,7 +22,7 @@ func TestAllCollectorsRegisterTogether(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	registry := prometheus.NewRegistry()
 
-	dns := newDNSCollector("primary", pihole.NewClient(pihole.Options{BaseURL: "http://127.0.0.1:1", Password: "x"}), logger)
+	dns := newDNSCollector("primary", pihole.NewClient(pihole.Options{BaseURL: "http://127.0.0.1:1", Password: "x"}), newDNSCounters(), logger)
 	leases := newDHCPLeasesCollector("primary", "/dev/null", logger)
 	logState := newDHCPLogState("primary", "/dev/null", logger)
 	dlog := newDHCPLogCollector("primary", logState)

--- a/internal/exporter/probe.go
+++ b/internal/exporter/probe.go
@@ -43,11 +43,12 @@ const pingTimeout = 10 * time.Second
 // goroutine that's never going to register.
 func NewProbeHandler(ctx context.Context, cfg *config.Config, overrides config.Overrides, logger *slog.Logger) http.Handler {
 	h := &probeHandler{
-		cfg:       cfg,
-		overrides: overrides,
-		logger:    logger,
-		clients:   make(map[string]*pihole.Client, len(cfg.Instances)),
-		dhcpLog:   make(map[string]*dhcpLogState, len(cfg.Instances)),
+		cfg:         cfg,
+		overrides:   overrides,
+		logger:      logger,
+		clients:     make(map[string]*pihole.Client, len(cfg.Instances)),
+		dhcpLog:     make(map[string]*dhcpLogState, len(cfg.Instances)),
+		dnsCounters: make(map[string]*dnsCounters, len(cfg.Instances)),
 	}
 	for id, inst := range cfg.Instances {
 		h.clients[id] = pihole.NewClient(pihole.Options{
@@ -56,6 +57,10 @@ func NewProbeHandler(ctx context.Context, cfg *config.Config, overrides config.O
 			Timeout:            inst.Timeout,
 			InsecureSkipVerify: inst.InsecureSkipVerify,
 		})
+		// dnsCounters is allocated unconditionally — toggling the DNS
+		// collector on/off across reloads shouldn't reset the
+		// monotonic counters in the meantime.
+		h.dnsCounters[id] = newDNSCounters()
 		if overrides.EffectiveDHCPLog(inst) {
 			state := newDHCPLogState(id, inst.Collectors.DHCPLog.Path, logger)
 			h.dhcpLog[id] = state
@@ -72,6 +77,12 @@ type probeHandler struct {
 	mu        sync.Mutex // guards clients + dhcpLog
 	clients   map[string]*pihole.Client
 	dhcpLog   map[string]*dhcpLogState
+
+	// dnsCounters holds the long-lived windowed→monotonic
+	// accumulators for each Pi-hole instance's DNS collector.
+	// Survives across /probe requests so we don't re-prime the
+	// baseline at every scrape.
+	dnsCounters map[string]*dnsCounters
 }
 
 func (h *probeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -138,7 +149,7 @@ func (h *probeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// the final say — see config.Overrides — so this entire chain
 	// reads from the resolved-effective view, not from the raw YAML.
 	if h.overrides.EffectiveDNS(inst) {
-		registry.MustRegister(newDNSCollector(target, client, logger))
+		registry.MustRegister(newDNSCollector(target, client, h.dnsCounters[target], logger))
 	}
 	if h.overrides.EffectiveDHCPLeases(inst) {
 		registry.MustRegister(newDHCPLeasesCollector(target, inst.Collectors.DHCPLeases.Path, logger))

--- a/internal/exporter/windowed_counter.go
+++ b/internal/exporter/windowed_counter.go
@@ -1,0 +1,93 @@
+package exporter
+
+import (
+	"strings"
+	"sync"
+)
+
+// windowedCounter turns a *windowed* upstream value (something that
+// reports "queries in the last N hours" rather than "queries since
+// upstream start") into a *monotonic* Prometheus counter the rate()
+// function can reason about correctly.
+//
+// Background — Pi-hole's /api/stats/summary returns 24-hour rolling
+// totals. The value drifts upward as new queries arrive but
+// periodically drops by a small amount (~once per 10 minutes, when
+// FTL ages the oldest stats bucket out of the window). Forwarding
+// those raw to Prometheus violates the counter contract — Prometheus
+// counters never decrease except across a process restart — and
+// rate() compensates for what it reads as "counter resets" by
+// adding the previous value to the new one. The result is huge
+// artificial spikes every flush cycle (a 207 195 → 206 424 drop is
+// interpreted as a +206 424 increase, producing thousands of qps
+// that didn't actually happen).
+//
+// Fix — observe upstream values at scrape time and accumulate only
+// the *positive* deltas across calls. When the upstream drops
+// (window flush), skip the delta: the queries between scrapes that
+// fell out of the window before we observed them are unrecoverable
+// from this signal. The undercount is bounded by the size of one
+// flush bucket (a few hundred queries every ten minutes on a busy
+// home network), and rate() now gives the correct qps with no
+// spike artefacts.
+//
+// Concurrency — observe() takes its own mutex. The probe handler
+// serializes scrapes for one instance, but the same accumulator can
+// be touched concurrently by Describe-vs-Collect on a shared
+// registry, so the lock is required.
+type windowedCounter struct {
+	mu       sync.Mutex
+	last     int64
+	lifetime int64
+	primed   bool
+}
+
+// observe records an upstream sample and returns the resulting
+// process-lifetime monotonic total. The first call seeds the
+// baseline and returns 0 — counting Pi-hole's pre-existing 24-hour
+// window as having happened "before we were watching" would emit a
+// large spike at exporter start.
+func (w *windowedCounter) observe(current int64) int64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.primed {
+		w.last = current
+		w.primed = true
+		return 0
+	}
+	if current >= w.last {
+		w.lifetime += current - w.last
+	}
+	// else: window flush; skip the negative delta.
+	w.last = current
+	return w.lifetime
+}
+
+// windowedCounters indexes accumulators by label tuple, used by
+// metrics whose label values are dynamic — queries_by_type,
+// queries_by_status, upstream_queries, … One accumulator is
+// allocated per distinct label tuple on first observation.
+type windowedCounters struct {
+	mu sync.Mutex
+	by map[string]*windowedCounter
+}
+
+func newWindowedCounters() *windowedCounters {
+	return &windowedCounters{by: map[string]*windowedCounter{}}
+}
+
+// observe records a sample for the given label tuple and returns
+// the resulting per-tuple lifetime total. The label tuple is keyed
+// by joining values with NUL — same shape Prometheus uses
+// internally for its sample maps, so distinct tuples never collide.
+func (wc *windowedCounters) observe(current int64, labelValues ...string) int64 {
+	key := strings.Join(labelValues, "\x00")
+	wc.mu.Lock()
+	w, ok := wc.by[key]
+	if !ok {
+		w = &windowedCounter{}
+		wc.by[key] = w
+	}
+	wc.mu.Unlock()
+	return w.observe(current)
+}

--- a/internal/exporter/windowed_counter_test.go
+++ b/internal/exporter/windowed_counter_test.go
@@ -1,0 +1,121 @@
+package exporter
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestWindowedCounter_PrimeReturnsZero(t *testing.T) {
+	t.Parallel()
+	var w windowedCounter
+	if got := w.observe(12345); got != 0 {
+		t.Errorf("first observe should seed baseline and return 0, got %d", got)
+	}
+}
+
+func TestWindowedCounter_PositiveDeltasAccumulate(t *testing.T) {
+	t.Parallel()
+	var w windowedCounter
+	w.observe(100) // prime
+	cases := []struct {
+		current int64
+		want    int64 // expected lifetime
+	}{
+		{105, 5},
+		{120, 20},
+		{200, 100},
+		{200, 100}, // no change
+	}
+	for i, tc := range cases {
+		if got := w.observe(tc.current); got != tc.want {
+			t.Errorf("step %d: observe(%d) = %d, want %d", i, tc.current, got, tc.want)
+		}
+	}
+}
+
+func TestWindowedCounter_FlushIsSkipped(t *testing.T) {
+	t.Parallel()
+	// Reproduces the failure mode behind PR #N: Pi-hole's 24h-rolling
+	// total drops at every FTL flush cycle. With raw forwarding the
+	// drop becomes a counter "reset" and rate() spikes. The
+	// accumulator must absorb the drop without rolling lifetime
+	// backwards or re-counting the dropped values on the next rise.
+	var w windowedCounter
+	w.observe(207_195) // prime at the value that observed the bug
+	got := w.observe(208_000)
+	if got != 805 {
+		t.Fatalf("post-prime delta: got %d, want 805", got)
+	}
+	got = w.observe(206_424) // window flush — counter drops 1 576 below previous
+	if got != 805 {
+		t.Fatalf("flush should not roll lifetime backwards: got %d, want 805", got)
+	}
+	got = w.observe(207_000) // post-flush growth; only the 207 000 - 206 424 = 576 above the new floor counts
+	if got != 805+576 {
+		t.Fatalf("post-flush growth: got %d, want %d", got, 805+576)
+	}
+}
+
+func TestWindowedCounter_ConcurrentObserveIsRaceFree(t *testing.T) {
+	t.Parallel()
+	// observe() must be safe under concurrent calls — promhttp can
+	// invoke Describe and Collect on overlapping goroutines on the
+	// same registered collector. Run -race against this and rely on
+	// the race detector to catch any unsynchronized field access;
+	// the value assertions only sanity-check that accumulation
+	// actually happens (a deadlocked or no-op observe() would leave
+	// lifetime at 0).
+	var w windowedCounter
+	w.observe(0) // prime
+
+	var wg sync.WaitGroup
+	const goroutines = 8
+	const ticks = 250
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 1; i <= ticks; i++ {
+				w.observe(int64(i))
+			}
+		}()
+	}
+	wg.Wait()
+	if w.lifetime < 1 {
+		t.Errorf("no accumulation observed under concurrent observe(): lifetime=%d", w.lifetime)
+	}
+}
+
+func TestWindowedCounters_KeyedByLabelTuple(t *testing.T) {
+	t.Parallel()
+	wc := newWindowedCounters()
+	// Two label tuples that share a prefix — must not collide via
+	// naive string concatenation.
+	if got := wc.observe(10, "a", "b"); got != 0 {
+		t.Errorf("first observe of (a, b): got %d, want 0 (prime)", got)
+	}
+	if got := wc.observe(10, "ab"); got != 0 {
+		t.Errorf("first observe of (ab): got %d, want 0 (prime, distinct tuple)", got)
+	}
+	if got := wc.observe(15, "a", "b"); got != 5 {
+		t.Errorf("second observe of (a, b): got %d, want 5", got)
+	}
+	if got := wc.observe(100, "ab"); got != 90 {
+		t.Errorf("second observe of (ab): got %d, want 90", got)
+	}
+	// (a, b) lifetime must not have been bumped by the "ab" call.
+	if got := wc.observe(15, "a", "b"); got != 5 {
+		t.Errorf("third observe of (a, b): got %d, want 5 (no change since previous)", got)
+	}
+}
+
+func TestWindowedCounters_NoLabelsKey(t *testing.T) {
+	t.Parallel()
+	wc := newWindowedCounters()
+	if got := wc.observe(50); got != 0 {
+		t.Fatalf("zero-label first observe: got %d, want 0", got)
+	}
+	if got := wc.observe(75); got != 25 {
+		t.Fatalf("zero-label second observe: got %d, want 25", got)
+	}
+}


### PR DESCRIPTION
## Problem

`/api/stats/summary` reports **24-hour rolling totals**, not since-start lifetime counters. The value drops by a small amount at every FTL flush cycle (~once per 10 minutes) as the oldest stats bucket ages out of the 24h window. The exporter forwards those raw, declared as Prometheus `CounterValue` — which violates the counter contract.

`rate()` interprets each drop as a counter reset and over-compensates by adding the previous value to the new one. The result is huge artificial spikes every ~10 minutes:

```
pihole_dns_queries_total drops every ~600s on a real Pi-hole:
  prev=206517 → cur=205863  Δ=−654
  prev=207195 → cur=206424  Δ=−771
  prev=208288 → cur=207542  Δ=−746
  prev=210663 → cur=210070  Δ=−593
  prev=212354 → cur=211678  Δ=−676
  prev=213694 → cur=213046  Δ=−648
6 drops in 1h, evenly spaced every 600s
```

`rate(pihole_dns_queries_total[5m])` reads ≈4 500 qps spikes on a network whose true average is ~340 qps. Every panel that uses `rate(<…>_total)` shows the artefact; gauge-backed panels (FTL CPU/memory, response time) stay smooth — proof the spikes aren't real traffic.

## Fix

Wrap each affected metric with a `windowedCounter` accumulator that:

1. Records only the **positive deltas** across scrapes and exposes a process-lifetime monotonic counter.
2. **Absorbs window flushes** (negative deltas) without rolling lifetime backwards. The queries that fell out of the window between scrapes are unrecoverable from this signal — bounded undercount of a few hundred queries per 10-minute flush, negligible on the qps scale `rate()` reports.
3. **Primes** on the first observation (returns 0) so we don't emit Pi-hole's pre-existing 24h window as a single delta-spike at exporter start.

Accumulator state lives on `probeHandler` so it survives across `/probe` requests — the collector itself is rebuilt per request to keep registry state isolated, but the long-lived state has to persist or every scrape would re-prime against the upstream's current 24h total.

## Affected metrics

Wrapped (windowed → monotonic):

- `pihole_dns_queries_total`
- `pihole_dns_queries_blocked_total`
- `pihole_dns_queries_forwarded_total`
- `pihole_dns_queries_cached_total`
- `pihole_dns_queries_by_type_total`
- `pihole_dns_queries_by_status_total`
- `pihole_dns_queries_by_reply_total`
- `pihole_dns_upstream_queries_total`

Pass-through (already monotonic — sourced from FTL's *since-FTL-start* counters; verified 0 decreases over a 1-hour Prometheus query):

- `pihole_dnsmasq_*_total` family
- `pihole_ftl_dhcp_messages_total`
- `pihole_ftl_dhcp_leases_allocated_total`
- `pihole_ftl_dhcp_leases_pruned_total`

## Behavior change for consumers

After this lands, `pihole_dns_queries_*_total` values are **lifetime since exporter start** rather than Pi-hole's rolling-24h figure. Concrete consequences:

- `rate(pihole_dns_queries_total[5m])` is now correct and smooth — primary motivation.
- Dashboards that read the **raw counter** as "queries today" will need to switch to `increase(pihole_dns_queries_total[24h])`. The existing reading was already misleading (it tracked a sliding 24h window, not midnight-to-now).
- The counter resets to 0 on exporter restart — standard Prometheus counter semantics; `rate()` and `increase()` handle it natively.

## Tests

- `windowed_counter_test.go` covers the accumulator directly: prime, accumulation, flush absorption, post-flush growth, multi-key isolation, race-detector-checked concurrency.
- `dns_test.go` adds `TestDNSCollector_WindowedCountersAcrossScrapes` — drives a real `dnsCollector` through four `Gather()` rounds against a fakePihole replaying *prime → growth → flush → post-flush growth* and asserts the wired-up values per round.
- Existing `TestDNSCollector_Summary` updated for prime-on-first-scrape semantics.

`make lint` and `go test -race -cover ./...` pass.

## Verification plan (post-merge)

Cut `v0.1.4`, redeploy on `mc-01`, capture before/after `rate(pihole_dns_queries_total[5m])` over a 30-minute window — spikes should disappear, line should track the gauge-backed `pihole_dns_queries_per_second` to within scrape-interval rounding.